### PR TITLE
Fix subprocess encoding for pandoc output

### DIFF
--- a/export_to_pdf.py
+++ b/export_to_pdf.py
@@ -130,6 +130,8 @@ def export_pdf(
             command,
             check=False,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
         )
         if result.returncode != 0:


### PR DESCRIPTION
## Summary
- ensure Pandoc subprocess output is decoded with UTF-8 and replaces invalid bytes to prevent UnicodeDecodeError on Windows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db981410d08333bc9ccb3558d7c542