### PR TITLE
修复 PDF 导出目录的跳转错误

### DIFF
--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -10,8 +10,8 @@ python tools/pdf_export/export_to_pdf.py
 
 1. 读取 `README.md` 中的目录结构，确保 PDF 的目录页与 README 保持一致；
 2. 若 `README.md` 未提供目录（或被忽略掉），脚本会自动按 `entries/` 下的实际目录与文件构建一个后备目录结构；
-3. 生成独立的封面页与目录页；
-4. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面；
+3. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
+4. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；
 5. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
 
 运行脚本前，请确保：


### PR DESCRIPTION
## 摘要
- 为导出的目录页生成稳定锚点并使用可点击的词条链接，修复 PDF 中目录无法跳转的问题
- 调整合并逻辑，在 PDF 大纲中按分类展示且避免重复的一级标题
- 更新导出说明文档，记录目录链接与新的大纲结构

## 测试
- python -m compileall tools/pdf_export/export_to_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68dbb5e3df108333b0e0fa685cb73511