### PR TITLE
修复 Docsify 部署缺少侧边与封面的问题

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - 更新或新增词条时，需同步维护 `index.md` 中的目录索引与 `README.md` 中的链接指向。
 - Markdown 文档采用一级标题表示词条名称，二级及以下标题依内容层级递增；若存在触发警示，请置于文首。
 - 提交前请检查 `ignore.md`，确保需要排除的文件已正确维护。
+- 若涉及 `docs/` 目录的 Docsify 配置，务必保留 `.nojekyll` 以防 GitHub Pages 过滤 `_sidebar.md`、`_coverpage.md` 等文件。
 
 ## PDF 导出脚本 (`tools/pdf_export/`)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ tools/
 ## 在线浏览（Docsify + GitHub Pages）
 
 - **直接预览**：仓库根目录新增的 [`index.html`](index.html) 基于 Docsify，即可在任何静态服务器或 GitHub Pages 中即时渲染 Markdown。推送到 `main` 分支后，在仓库的 “Settings → Pages” 中选择 `Deploy from a branch` 与根目录（`/`），即可获得在线阅读地址。
+- **避免 Jekyll 过滤**：若部署到 GitHub Pages，请确保根目录存在 `.nojekyll` 文件（本仓库已在 `docs/` 目录提供），以便保留 `_sidebar.md`、`_coverpage.md` 等以下划线开头的 Docsify 资源。
 - **国内访问提示**：Docsify 依赖 jsDelivr 的 CDN，国内偶尔会存在访问波动。如需更稳定的访问速度，可在自己的分叉中改用 [unpkg](https://unpkg.com/docsify) 或配置自托管的静态资源。
 - **本地验证**：若需在本地检视样式，推荐使用 Docsify 官方 CLI（`npx docsify serve .`）或任意静态服务器（如 `python -m http.server`）启动预览，再访问 `http://localhost:3000`（或对应端口）。
 

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from running Jekyll so Docsify assets with leading underscores remain accessible.


### PR DESCRIPTION
## Summary
- 在 docs 目录新增 `.nojekyll`，确保 GitHub Pages 不会忽略 `_sidebar.md` 与 `_coverpage.md`
- 在 README 与 AGENTS 指南中说明 `.nojekyll` 的必要性与维护注意事项

## Testing
- 未运行测试（文档更新）

------
https://chatgpt.com/codex/tasks/task_e_68dcb419748c8333a3b7dbcd37bc3261