### PR TITLE
修复首页导航跳转到 404 的问题

### DIFF
--- a/404.html
+++ b/404.html
@@ -69,13 +69,14 @@
           baseSegments.length > 0 ? `/${baseSegments.join("/")}/` : "/";
         const docPath = docSegments.join("/");
         const normalizedBase = basePath.replace(/\/+$/, "/");
+        const docTarget = docPath ? docPath : "README_wiki";
         const target =
           normalizedBase +
           "#/" +
-          (docPath ? docPath : "") +
+          docTarget +
           (search || "") +
           (hash || "");
-        const fallbackHome = `${normalizedBase}#/`;
+        const fallbackHome = `${normalizedBase}#/README_wiki`;
         const fallbackLink = document.getElementById("fallback");
         fallbackLink.href = docPath ? target : fallbackHome;
         try {

--- a/_404.md
+++ b/_404.md
@@ -4,7 +4,7 @@
 
 文档可能已经移动或名称有所调整。你可以：
 
-- 返回 [首页](#/)
+- 返回 [首页](#/README_wiki)
 - 使用左侧目录或上方搜索框寻找需要的内容
 - 在 GitHub 上提交 [Issue](https://github.com/kuliantnt/plurality_wiki/issues) 告知我们失效链接
 

--- a/_navbar.md
+++ b/_navbar.md
@@ -1,4 +1,4 @@
 * 快速入口
-  * [首页](README_wiki.md)
+  * [首页](#/README_wiki)
   * [术语索引](index.md)
   * [GitHub 仓库](https://github.com/kuliantnt/plurality_wiki)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,5 +1,5 @@
 - **总览**
-  - [首页](README_wiki.md)
+  - [首页](#/README_wiki)
   - [术语索引](index.md)
 
 - **核心词条**


### PR DESCRIPTION
## 动机
- 修复导航栏和 404 页面返回首页时误入 404 的问题

## 主要改动
- 将导航栏与侧边栏的“首页”链接改为 Docsify 哈希路由，确保始终跳转到 README_wiki
- 调整自定义 404 页与 Fallback 页面脚本，在缺省情况下统一重定向到 `#/README_wiki`

## 潜在风险
- Docsify 路由配置发生变化时，需要同步更新 404 重定向脚本中的首页路径

## 相关链接
- README_wiki.md（站点首页）


------
https://chatgpt.com/codex/tasks/task_e_68dcc73f6c9483338a0ffc4e970bf84c