### PR TITLE
修复 Docsify 路由跳转缺失 entries 前缀

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,82 @@
         );
         canonicalizeHash();
 
+        const shouldHandleInternally = (href) => {
+          if (!href || href.startsWith("#")) return false;
+          if (/^[a-zA-Z]+:/i.test(href)) return false;
+          if (href.startsWith("//")) return false;
+          return true;
+        };
+
+        const resolveTarget = (href) => {
+          const [pathAndQuery = "", hashFragment = ""] = href.split("#");
+          const [rawPath = "", rawQuery = ""] = pathAndQuery.split("?");
+          const queryPart = rawQuery ? `?${rawQuery}` : "";
+
+          const currentBaseSegments = (() => {
+            const { hash } = window.location;
+            if (!hash || !hash.startsWith("#/")) return [];
+
+            const [currentPath = ""] = hash.slice(2).split("?");
+            const segments = currentPath.split("/").filter(Boolean);
+            if (segments.length) segments.pop();
+            return segments;
+          })();
+
+          const isAbsolutePath =
+            rawPath.startsWith("/") || rawPath.startsWith("entries/");
+          const baseTrimmed = basePath.replace(/^\/+|\/+$/g, "");
+          let workingPath = rawPath.replace(/^\/+/, "");
+          if (baseTrimmed && workingPath.startsWith(`${baseTrimmed}/`)) {
+            workingPath = workingPath.slice(baseTrimmed.length + 1);
+          }
+          const pathSegments = workingPath
+            .split("/")
+            .filter((segment) => segment.length);
+
+          const stack = isAbsolutePath ? [] : [...currentBaseSegments];
+
+          for (const segment of pathSegments) {
+            if (segment === ".") continue;
+            if (segment === "..") {
+              if (stack.length) stack.pop();
+              continue;
+            }
+            stack.push(segment);
+          }
+
+          const resolvedPath = stack.join("/");
+          const anchorQuery = hashFragment
+            ? (queryPart ? `${queryPart}&` : "?") +
+              `id=${encodeURIComponent(hashFragment)}`
+            : queryPart;
+
+          return `${resolvedPath}${anchorQuery}`;
+        };
+
+        document.addEventListener("click", (event) => {
+          const anchor = event.target.closest("a[href]");
+          if (!anchor) return;
+          if (anchor.target && anchor.target !== "" && anchor.target !== "_self")
+            return;
+
+          const href = anchor.getAttribute("href");
+          if (!shouldHandleInternally(href)) return;
+
+          event.preventDefault();
+
+          const target = resolveTarget(href);
+          const normalized = normalizePath(target);
+          const cleanPath = normalized.replace(/\.md(?=$|\?)/i, "");
+          const newHash = `#/${cleanPath}`;
+
+          if (window.location.hash !== newHash) {
+            window.location.hash = newHash;
+          } else {
+            canonicalizeHash(true);
+          }
+        });
+
         window.$docsify = {
           name: "多意识体Wikipedia",
           repo: "kuliantnt/plurality_wiki",


### PR DESCRIPTION
## 摘要
- 拦截站内链接点击事件，统一转换为 Docsify 路由哈希，避免跳转路径丢失 `entries/` 前缀导致 404
- 新增相对路径解析逻辑，兼容跨目录引用与锚点，保持现有条目链接正常工作

## 测试
- 未执行自动化测试（前端改动，暂无可用脚本）

------
https://chatgpt.com/codex/tasks/task_e_68dcfeef04b08333ac854d3cfba77d33