### PR TITLE
docs: 补充 PDF 导出模块中文注释

### DIFF
--- a/tools/pdf_export/export_to_pdf.py
+++ b/tools/pdf_export/export_to_pdf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compatibility wrapper around the :mod:`pdf_export` package CLI."""
+"""PDF 导出工具入口脚本，作为 ``pdf_export`` 包命令行的简单封装。"""
 
 from __future__ import annotations
 
@@ -9,6 +9,9 @@ from pdf_export.cli import main
 
 
 if __name__ == "__main__":
+    # 调用核心 CLI 入口，补充注释说明为何捕获 SystemExit：
+    # - Pandoc 或依赖缺失时，子模块会通过 SystemExit 返回错误信息。
+    # - 这里捕获后打印到标准错误输出，再重新抛出保持原始退出码。
     try:
         main()
     except SystemExit as exc:

--- a/tools/pdf_export/pdf_export/__init__.py
+++ b/tools/pdf_export/pdf_export/__init__.py
@@ -1,4 +1,4 @@
-"""PDF export package for the Plurality Wiki project."""
+"""Plurality Wiki PDF 导出功能的包入口，集中暴露公共接口。"""
 
 from .cli import main
 

--- a/tools/pdf_export/pdf_export/__main__.py
+++ b/tools/pdf_export/pdf_export/__main__.py
@@ -1,4 +1,4 @@
-"""Allow running ``python -m pdf_export``."""
+"""支持通过 ``python -m pdf_export`` 执行命令行入口。"""
 
 from __future__ import annotations
 

--- a/tools/pdf_export/pdf_export/cli.py
+++ b/tools/pdf_export/pdf_export/cli.py
@@ -1,4 +1,4 @@
-"""Command line interface for the PDF exporter."""
+"""PDF 导出工具的命令行入口，负责解析参数并触发导出流程。"""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from .structure import collect_markdown_structure
 
 
 def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    """Return parsed command line arguments."""
+    """解析命令行参数并返回 ``argparse.Namespace`` 结果。"""
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -89,7 +89,7 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """Entry point used by both the wrapper script and ``python -m``."""
+    """统一的命令行入口，供封装脚本与 ``python -m`` 复用。"""
 
     args = parse_arguments(argv)
     check_requirements(args.pandoc)

--- a/tools/pdf_export/pdf_export/constants.py
+++ b/tools/pdf_export/pdf_export/constants.py
@@ -1,4 +1,4 @@
-"""Module containing constant values used across the exporter."""
+"""集中管理导出流程会用到的常量配置，便于统一维护。"""
 
 from __future__ import annotations
 

--- a/tools/pdf_export/pdf_export/exporter.py
+++ b/tools/pdf_export/pdf_export/exporter.py
@@ -1,4 +1,4 @@
-"""Pandoc integration helpers."""
+"""与 Pandoc 交互的封装函数，负责实际的 PDF 渲染。"""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ def export_pdf(
     pdf_engine: str | None,
     cjk_font: str | None,
 ) -> None:
-    """Invoke Pandoc to render ``markdown_content`` into ``output_path``."""
+    """调用 Pandoc 将 ``markdown_content`` 渲染为 ``output_path`` 指定的文件。"""
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".md", delete=False) as handle:
         handle.write(markdown_content)

--- a/tools/pdf_export/pdf_export/ignore_loader.py
+++ b/tools/pdf_export/pdf_export/ignore_loader.py
@@ -1,4 +1,4 @@
-"""Helpers for reading ignore rules from ``ignore.md``."""
+"""从 ``ignore.md`` 读取忽略规则的辅助函数。"""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from .paths import PROJECT_ROOT
 
 
 def load_ignore_rules(path: Path) -> IgnoreRules:
-    """Load ignore rules from ``ignore.md`` similar to a subset of .gitignore."""
+    """解析 ``ignore.md`` 并返回与 .gitignore 类似的忽略配置。"""
 
     if not path.exists():
         return IgnoreRules(files=frozenset(), directories=frozenset())

--- a/tools/pdf_export/pdf_export/markdown.py
+++ b/tools/pdf_export/pdf_export/markdown.py
@@ -1,4 +1,4 @@
-"""Helpers for building the combined markdown document."""
+"""组合 Markdown 内容、生成目录与封面等辅助函数集合。"""
 
 from __future__ import annotations
 
@@ -25,13 +25,13 @@ LATEX_SPECIAL_CHARS = {
 
 
 def escape_latex(text: str) -> str:
-    """Escape LaTeX special characters in ``text``."""
+    """对 ``text`` 中的 LaTeX 特殊字符做转义。"""
 
     return "".join(LATEX_SPECIAL_CHARS.get(ch, ch) for ch in text)
 
 
 def infer_entry_title(path: Path) -> str:
-    """Best-effort guess of an entry's display title."""
+    """尽力从条目文件推断展示标题，失败时回退到文件名。"""
 
     heading_pattern = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$")
     try:
@@ -46,7 +46,7 @@ def infer_entry_title(path: Path) -> str:
 
 
 def shift_heading_levels(markdown: str, offset: int) -> str:
-    """Increase heading levels by ``offset`` while keeping Pandoc fences intact."""
+    """将所有标题级别整体上移 ``offset``，同时保留 Pandoc 代码块。"""
 
     if offset == 0:
         return markdown
@@ -62,7 +62,7 @@ def shift_heading_levels(markdown: str, offset: int) -> str:
 
 
 def build_entry_anchor(path: Path) -> str:
-    """Return a stable anchor identifier for ``path`` within the combined PDF."""
+    """基于路径生成稳定锚点，确保合并文档中的引用可重复。"""
 
     relative = path.relative_to(PROJECT_ROOT)
     digest = hashlib.sha1(relative.as_posix().encode("utf-8")).hexdigest()[:10]
@@ -70,7 +70,7 @@ def build_entry_anchor(path: Path) -> str:
 
 
 def strip_primary_heading(content: str, title: str) -> str:
-    """Remove the first heading that matches ``title`` from ``content``."""
+    """移除与 ``title`` 相同的首个标题，避免重复标题干扰。"""
 
     heading_re = re.compile(rf"^#{{1,6}}\s+{re.escape(title)}\s*$")
     lines = content.splitlines()
@@ -98,10 +98,10 @@ def build_cover_page(
     date_text: str | None,
     footer_text: str | None,
 ) -> str:
-    """Return a standalone cover page using LaTeX's titlepage environment."""
+    """使用 LaTeX ``titlepage`` 环境构建封面页。"""
 
     def _format_line(size_command: str, text: str) -> str:
-        """Render ``text`` inside a LaTeX sizing command."""
+        """以指定字号指令渲染 ``text``，同时完成转义。"""
 
         escaped = escape_latex(text.strip())
         return f"{{{size_command} {escaped}\\par}}"
@@ -143,7 +143,7 @@ def build_cover_page(
 
 
 def build_directory_page(structure: CategoryStructure) -> str:
-    """Construct a table-of-contents page based on README categories."""
+    """根据 README/目录结构生成目录页内容。"""
 
     lines: list[str] = ["# 目录", ""]
 
@@ -169,7 +169,7 @@ def build_combined_markdown(
     cover_date: str | None,
     cover_footer: str | None,
 ) -> str:
-    """Combine all markdown files into a single string."""
+    """将所有 Markdown 文件拼接为单一字符串供 Pandoc 使用。"""
 
     parts: list[str] = []
 

--- a/tools/pdf_export/pdf_export/models.py
+++ b/tools/pdf_export/pdf_export/models.py
@@ -1,4 +1,4 @@
-"""Dataclasses and type aliases used by the exporter."""
+"""导出流程中共享的数据结构与类型别名定义。"""
 
 from __future__ import annotations
 
@@ -12,13 +12,13 @@ CategoryStructure = Sequence[tuple[str, Sequence[Path]]]
 
 @dataclass(frozen=True)
 class IgnoreRules:
-    """A minimal set of ignore rules similar to ``.gitignore``."""
+    """表示与 ``.gitignore`` 类似的忽略规则集合。"""
 
     files: frozenset[Path]
     directories: frozenset[Path]
 
     def matches(self, path: Path) -> bool:
-        """Return ``True`` if ``path`` should be skipped when exporting."""
+        """判断 ``path`` 是否应在导出时被跳过。"""
 
         resolved = path.resolve()
         if resolved in self.files:
@@ -32,7 +32,7 @@ class IgnoreRules:
 
 @dataclass
 class PandocExportError(RuntimeError):
-    """Raised when Pandoc fails to render the combined markdown."""
+    """当 Pandoc 渲染合并后的 Markdown 失败时抛出的异常。"""
 
     command: Sequence[str]
     stderr: str

--- a/tools/pdf_export/pdf_export/paths.py
+++ b/tools/pdf_export/pdf_export/paths.py
@@ -1,4 +1,4 @@
-"""Path helpers for the PDF exporter."""
+"""提供 PDF 导出脚本使用的路径常量，保证目录定位一致。"""
 
 from __future__ import annotations
 

--- a/tools/pdf_export/pdf_export/requirements.py
+++ b/tools/pdf_export/pdf_export/requirements.py
@@ -1,4 +1,4 @@
-"""Runtime requirement helpers for the PDF exporter."""
+"""校验运行时依赖并提供外部工具探测函数。"""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from .constants import CJK_FONT_CANDIDATES, DEFAULT_PDF_ENGINES
 
 
 def check_requirements(pandoc_cmd: str) -> None:
-    """Ensure that the external tools required by the script are available."""
+    """确认导出脚本所需的 Pandoc 命令是否可用。"""
 
     if shutil.which(pandoc_cmd) is None:
         raise SystemExit(
@@ -26,7 +26,7 @@ def _first_available(executables: Iterable[str]) -> str | None:
 
 
 def detect_pdf_engine(preferred: str | None) -> str | None:
-    """Find an available PDF engine for Pandoc, if any."""
+    """查找可供 Pandoc 使用的 PDF 引擎并返回名称。"""
 
     if preferred:
         if shutil.which(preferred) is None:
@@ -39,7 +39,7 @@ def detect_pdf_engine(preferred: str | None) -> str | None:
 
 
 def detect_cjk_font() -> str | None:
-    """Return the first available Chinese font family, if any."""
+    """检测系统已安装的中文字体并返回首个匹配项。"""
 
     if shutil.which("fc-list") is None:
         return None

--- a/tools/pdf_export/pdf_export/structure.py
+++ b/tools/pdf_export/pdf_export/structure.py
@@ -1,4 +1,4 @@
-"""Gather markdown files and ordering information from the repository."""
+"""整理仓库内的 Markdown 文件并生成导出顺序。"""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from .paths import ENTRIES_DIR, INDEX_PATH, PROJECT_ROOT, README_PATH
 
 
 def parse_markdown_index(index_path: Path, ignore: IgnoreRules) -> CategoryStructure:
-    """Parse a markdown index file to determine the desired export order."""
+    """解析目录 Markdown，确定导出所需的条目顺序。"""
 
     if not index_path.exists():
         return []
@@ -54,7 +54,7 @@ def parse_markdown_index(index_path: Path, ignore: IgnoreRules) -> CategoryStruc
 
 
 def collect_markdown_structure(ignore: IgnoreRules) -> CategoryStructure:
-    """Collect markdown files following the index order."""
+    """依据索引顺序收集 Markdown 文件，供后续导出使用。"""
 
     categories = list(parse_markdown_index(INDEX_PATH, ignore))
     if not categories:


### PR DESCRIPTION
## 变更动机
- 按照反馈为 `tools/pdf_export/` 下的 Python 模块补充中文注释，方便阅读与维护。

## 主要改动
- 将包入口、命令行入口及各功能模块的文件级文档字符串更新为中文说明。
- 调整核心函数的中文文档字符串与内嵌注释，确保行为解释完整一致。

## 潜在风险
- 仅涉及文档字符串更新，不影响运行逻辑，风险极低。

## 相关条目
- 无词条内容调整。


------
https://chatgpt.com/codex/tasks/task_e_68dd0ee8e0c48333be77da2088316588