### PR TITLE
fix: 修复移动端术语表滚动问题

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -230,14 +230,19 @@ button, .cover .buttons a{
 
 /* 表格美化 */
 .markdown-section table{
-  border-collapse: collapse;
-  overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0;
   display: block;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   border-radius: 14px;
   box-shadow: var(--shadow);
   background: var(--c-card);
   border: 1px solid color-mix(in oklab, var(--c-muted) 18%, transparent);
+  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 .markdown-section table th,
 .markdown-section table td{


### PR DESCRIPTION
## 摘要
- 调整 Docsify 全站表格样式，使其在移动端以自适应宽度呈现并支持横向滚动
- 更新表格的折叠与滚动参数，维持现有圆角与阴影视觉效果

## 动机
手机访问 Glossary 等长表格时列宽被压缩，内容换行导致信息难以阅读，需要优化移动端展示体验。

## 变更
- 将 `.markdown-section table` 的折叠方式改为 `separate` 并设置 `border-spacing`，避免圆角被裁切
- 设定 `min-width` 与 `overflow-x: auto`，在小屏幕上提供横向滚动
- 添加 `-webkit-overflow-scrolling: touch` 以提升触控滑动体验

## 风险
- 样式统一作用于所有 Markdown 表格，需确认其他页面在桌面端依旧正常。未观察到额外风险。

## 相关
- Glossary.md

------
https://chatgpt.com/codex/tasks/task_e_68dd3d9d53ac8333af0f47c91fff4656