### PR TITLE
fix: 优化术语表横向滚动体验

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -233,13 +233,12 @@ button, .cover .buttons a{
   border-collapse: separate;
   border-spacing: 0;
   display: block;
-  width: max-content;
-  min-width: 100%;
+  width: 100%;
+  max-width: 100%;
   border-radius: 14px;
   box-shadow: var(--shadow);
   background: var(--c-card);
   border: 1px solid color-mix(in oklab, var(--c-muted) 18%, transparent);
-  overflow: hidden;
   overflow-x: auto;
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
@@ -248,6 +247,19 @@ button, .cover .buttons a{
 .markdown-section table td{
   padding: .6rem .8rem;
   border-bottom: 1px solid color-mix(in oklab, var(--c-muted) 18%, transparent);
+  white-space: nowrap;
+}
+.markdown-section table td:nth-child(3){
+  white-space: normal;
+  min-width: 320px;
+}
+.markdown-section table th:first-child,
+.markdown-section table td:first-child{
+  min-width: 220px;
+}
+.markdown-section table th:nth-child(2),
+.markdown-section table td:nth-child(2){
+  min-width: 140px;
 }
 .markdown-section table thead{
   background: color-mix(in oklab, var(--c-brand) 14%, var(--c-card));


### PR DESCRIPTION
## 概述
- 调整 `custom.css` 中的表格样式，限制宽度并新增列最小宽度，确保 Glossary 术语表在窄屏下出现横向滚动条
- 统一前两列为单行展示，第三列保持换行但设置最小宽度，改善桌面与移动端的可读性

## 测试
- 通过 `python3 -m http.server 3000` 启动本地预览并在浏览器中确认表格支持横向滚动

------
https://chatgpt.com/codex/tasks/task_e_68dd3f11a3188333bd374f4101121734