### PR TITLE
优化 PDF 导出封面与暗黑模式样式

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -43,6 +43,18 @@ html, body{
   padding: .8em 1em;
   border-radius: var(--radius);
 }
+:root.dark .markdown-section h1,
+:root.dark .markdown-section h2,
+:root.dark .markdown-section h3,
+:root.dark .markdown-section h4,
+:root.dark .markdown-section h5,
+:root.dark .markdown-section h6{
+  color: #F2F6FF;
+}
+:root.dark .markdown-section strong,
+:root.dark .markdown-section b{
+  color: #F8FBFF;
+}
 
 /* 顶部导航栏 */
 .app-nav{

--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -47,7 +47,8 @@ python tools/pdf_export/export_to_pdf.py --pdf-engine xelatex
 
 - 若不需要封面，可以添加 `--no-cover`。
 - `--cover-title`、`--cover-subtitle`、`--cover-date` 可覆盖封面的默认文字。
-- `--cover-footer` 用于自定义封面底部的“plurality_wiki 项目”字样，传入空字符串即可移除该行。
+- 封面标题下方默认会展示可点击的“在线版本”链接，指向 <https://plurality-wiki.pages.dev/#/>，便于读者快速跳转至网页版内容。
+- `--cover-footer` 用于自定义封面底部的“plurality_wiki 项目”字样（默认以更大字号斜体排版），传入空字符串即可移除该行。
 - 目录页会根据 README 的分组与词条自动生成，默认不再展示各词条内部的小节标题。
 
 如需进一步自定义输出文件名或其他设置，可执行 `python tools/pdf_export/export_to_pdf.py --help` 查看全部参数。

--- a/tools/pdf_export/pdf_export/cli.py
+++ b/tools/pdf_export/pdf_export/cli.py
@@ -10,6 +10,8 @@ from typing import Sequence
 
 from .constants import (
     DEFAULT_COVER_FOOTER,
+    DEFAULT_COVER_ONLINE_LINK_LABEL,
+    DEFAULT_COVER_ONLINE_LINK_URL,
     DEFAULT_COVER_SUBTITLE,
     DEFAULT_COVER_TITLE,
 )
@@ -126,6 +128,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         cover_subtitle=cover_subtitle,
         cover_date=cover_date,
         cover_footer=cover_footer,
+        cover_online_link_label=DEFAULT_COVER_ONLINE_LINK_LABEL,
+        cover_online_link_url=DEFAULT_COVER_ONLINE_LINK_URL,
     )
 
     try:

--- a/tools/pdf_export/pdf_export/constants.py
+++ b/tools/pdf_export/pdf_export/constants.py
@@ -25,3 +25,5 @@ CJK_FONT_CANDIDATES = [
 DEFAULT_COVER_TITLE = "多重意识体系统知识库"
 DEFAULT_COVER_SUBTITLE = "Plurality Wiki"
 DEFAULT_COVER_FOOTER = "脸脸系统"
+DEFAULT_COVER_ONLINE_LINK_LABEL = "在线版本"
+DEFAULT_COVER_ONLINE_LINK_URL = "https://plurality-wiki.pages.dev/#/"


### PR DESCRIPTION
## 改动动机
- 希望 PDF 导出成品能直接引导读者访问在线版，同时让封面底部署名更醒目。
- 暗黑模式下粗体与标题颜色偏暗，影响网页端可读性。

## 主要变更
- 为 PDF 默认封面加入可点击的“在线版本”链接，并放大封面底部“脸脸系统”署名字号。
- 扩展导出脚本封面构建逻辑，统一管理链接常量并更新使用说明。
- 调整暗黑模式下标题与粗体文字的颜色，提高整体对比度，同时补充预览截图。

## 潜在风险
- 需要 Pandoc 模板正确加载 `hyperref` 支持，以确保封面链接可点击。

## 相关条目或链接
- `tools/pdf_export` 导出脚本
- 站点样式表 `assets/custom.css`


------
https://chatgpt.com/codex/tasks/task_e_68de2521adf0833389c830ff833268aa