### PR TITLE
fix: 修复 Docsify 最后更新时间显示

### DIFF
--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -8,13 +8,17 @@
   let latestVM = null;
 
   function registerPlugin() {
-    window.$docsify = window.$docsify || {
-      timeUpdater: {
-        text: "<div align='right' style='color:#999;font-size:12px'>最后更新：{docsify-updated}</div>",
-        formatUpdated: "{YYYY}-{MM}-{DD} {HH}:{mm}",
+    window.$docsify = window.$docsify || {};
+    if (!window.$docsify.formatUpdated) {
+      window.$docsify.formatUpdated = "{YYYY}-{MM}-{DD} {HH}:{mm}";
+    }
+    if (!window.$docsify.timeUpdater) {
+      window.$docsify.timeUpdater = {
+        text:
+          "<div align='right' style='color:#999;font-size:12px'>最后更新：{docsify-updated}</div>",
         whereToPlace: "bottom",
-      },
-    };
+      };
+    }
     const originalPlugins = window.$docsify.plugins || [];
     window.$docsify.plugins = [].concat(titleSearchPlugin, originalPlugins);
   }

--- a/index.html
+++ b/index.html
@@ -178,6 +178,14 @@
           subMaxLevel: 2,
           auto2top: true,
 
+          // 最后更新时间配置
+          formatUpdated: "{YYYY}-{MM}-{DD} {HH}:{mm}",
+          timeUpdater: {
+            text:
+              "<div align='right' style='color:#999;font-size:12px'>最后更新：{docsify-updated}</div>",
+            whereToPlace: "bottom",
+          },
+
           // 首页直接展示 Main_Page，无需封面
           coverpage: false,
           onlyCover: false,


### PR DESCRIPTION
## 摘要
- 在 Docsify 配置中补充 formatUpdated 与 timeUpdater，确保“最后更新”文本正常渲染
- 调整自定义搜索脚本，避免覆盖既有 Docsify 配置并提供时间插件默认值

## 测试
- 未执行自动化测试（前端配置变更）

------
https://chatgpt.com/codex/tasks/task_e_68de2bb8710483338d871938b656bb91