### PR TITLE
feat: 为 #/recent 页面注入最近更新逻辑

### DIFF
--- a/assets/recent-page.js
+++ b/assets/recent-page.js
@@ -1,0 +1,141 @@
+(function () {
+  const RECENT_ROUTE = "/recent";
+  const DATA_URL = "./assets/last-updated.json";
+  const ENTRY_LIMIT = 20;
+  const CONTAINER_CLASS = "recent-page";
+
+  let cachedPromise = null;
+
+  function fetchUpdates() {
+    if (!cachedPromise) {
+      cachedPromise = fetch(DATA_URL, { cache: "no-store" })
+        .then((response) => (response.ok ? response.json() : {}))
+        .catch(() => ({}));
+    }
+    return cachedPromise;
+  }
+
+  function toRoutePath(filePath) {
+    const withoutExt = filePath.replace(/\.md$/i, "");
+    const encoded = withoutExt
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    return `#/${encoded}`;
+  }
+
+  function toDisplayName(filePath) {
+    return filePath.replace(/\.md$/i, "").replace(/^entries\//i, "");
+  }
+
+  function formatDate(isoString) {
+    if (!isoString) return "";
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return "";
+    const pad = (value) => String(value).padStart(2, "0");
+    const year = date.getFullYear();
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    const hours = pad(date.getHours());
+    const minutes = pad(date.getMinutes());
+    return `${year}/${month}/${day} ${hours}:${minutes}`;
+  }
+
+  function normalizeRoutePath(route) {
+    if (!route || !route.path) return "";
+    const [path] = String(route.path).split("?");
+    const trimmed = path.replace(/\/+$/, "");
+    if (!trimmed) return "/";
+    return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  }
+
+  function buildCommitLink(commit) {
+    if (!commit) return "";
+    const repo = (window.$docsify && window.$docsify.repo) || "";
+    if (!repo) return "";
+
+    const normalizedRepo = repo.replace(/\.git$/, "");
+    const url = /^(https?:)?\/\//i.test(normalizedRepo)
+      ? `${normalizedRepo.replace(/\/+$/, "")}/commit/${commit}`
+      : `https://github.com/${normalizedRepo.replace(/^\/+/, "")}/commit/${commit}`;
+
+    return `<a href="${url}" target="_blank" rel="noopener">${commit.slice(
+      0,
+      7
+    )}</a>`;
+  }
+
+  function renderList(items) {
+    if (!items.length) {
+      return `
+        <section class="${CONTAINER_CLASS}">
+          <h1>最近更新</h1>
+          <p>暂无最近更新记录。</p>
+        </section>
+      `;
+    }
+
+    const listItems = items
+      .map(({ path, info }) => {
+        const displayName = toDisplayName(path);
+        const formattedDate = formatDate(info.updated);
+        const commitLink = buildCommitLink(info.commit);
+        const meta = [formattedDate, commitLink]
+          .filter(Boolean)
+          .join(" · ");
+        return `
+          <li>
+            <a href="${toRoutePath(path)}">${displayName}</a>
+            ${meta ? `<div class="meta">${meta}</div>` : ""}
+          </li>
+        `;
+      })
+      .join("");
+
+    return `
+      <section class="${CONTAINER_CLASS}">
+        <h1>最近更新</h1>
+        <p>以下列表基于仓库同步的 <code>last-updated.json</code> 自动生成。</p>
+        <ol>
+          ${listItems}
+        </ol>
+      </section>
+    `;
+  }
+
+  function generateContent(map) {
+    const items = Object.keys(map || {})
+      .map((path) => ({ path, info: map[path] || {} }))
+      .filter((item) => item.info && item.info.updated)
+      .sort((a, b) => {
+        const aTime = new Date(a.info.updated).getTime();
+        const bTime = new Date(b.info.updated).getTime();
+        return Number.isNaN(bTime) - Number.isNaN(aTime) || bTime - aTime;
+      })
+      .slice(0, ENTRY_LIMIT);
+
+    return renderList(items);
+  }
+
+  window.$docsify = window.$docsify || {};
+  const userPlugins = window.$docsify.plugins || [];
+
+  window.$docsify.plugins = [].concat(function (hook, vm) {
+    hook.afterEach(function (html, next) {
+      const currentPath = normalizeRoutePath(vm.route);
+      if (currentPath !== RECENT_ROUTE) {
+        next(html);
+        return;
+      }
+
+      fetchUpdates()
+        .then((map) => {
+          next(generateContent(map));
+        })
+        .catch(() => {
+          next(generateContent({}));
+        });
+    });
+  }, userPlugins);
+})();

--- a/index.html
+++ b/index.html
@@ -315,6 +315,9 @@
       })();
     </script>
 
+    <!-- 最近更新页面自动生成 -->
+    <script src="./assets/recent-page.js"></script>
+
     <!-- Docsify 核心 -->
     <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
 


### PR DESCRIPTION
## 摘要
- 新增 `assets/recent-page.js`，在 Docsify 插件中读取 `last-updated.json` 并生成最近更新列表
- 在 `index.html` 中引入最近更新脚本，保持现有初始化语义

## 测试
- 未执行（静态资源变更）

------
https://chatgpt.com/codex/tasks/task_e_68de860870308333a829d14a2040beef