### PR TITLE
docs: 更新 README 中 CI 徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs status](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://kuliantnt.github.io/plurality_wiki/#/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](CONTRIBUTING.md)
 [![Stars](https://img.shields.io/github/stars/kuliantnt/plurality_wiki?style=social)](https://github.com/kuliantnt/plurality_wiki/stargazers)
-[![Build](https://github.com/kuliantnt/plurality_wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/kuliantnt/plurality_wiki/actions)
+[![CI 状态](https://img.shields.io/github/actions/workflow/status/kuliantnt/plurality_wiki/ci.yml?label=CI&logo=github)](https://github.com/kuliantnt/plurality_wiki/actions/workflows/ci.yml)
 
 ---
 


### PR DESCRIPTION
## 摘要
- 将 CI 徽章替换为 shields.io 提供的 GitHub Actions 状态徽章，避免原始链接加载异常

## 测试
- 文档更新，无需测试

------
https://chatgpt.com/codex/tasks/task_e_68df8557291483338c37752cbcd44223