### PR TITLE
docs: 拆分术语表分类

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -4,102 +4,131 @@
 
 ## 常用术语（Common Terms）
 
-| 术语                                                                           | 中文参考译名      | 社群用法/备注                              |
-| ---------------------------------------------------------------------------- | ----------- | ------------------------------------ |
-| [Adaptive](entries/系统角色与类型/Adaptive.md)                    | 适应型         | 埃蒙加德分类法标签之一，强调系统因应对创伤或长期压力而形成。      |
-| [Admin](entries/系统角色与类型/Admin.md)                                              | 管理者         | 系统中负责维护秩序、管理资源与协调事务的成员或团队角色。         |
-| [Alexithymia](entries/诊断与临床/Alexithymia.md)                                         | 述情障碍        | 描述难以识别、理解与表达情绪的体验，常与创伤或解离共现。         |
-| [Alcohol-Induced Dissociation](entries/系统体验与机制/Alcohol-Induced-Dissociation.md) | 醉酒解离        | 比喻解离发作时动作迟缓、语句含混等像醉酒的体验，并不一定涉及酒精摄入。 |
-| [Alter](entries/系统角色与类型/Alter.md)                                               | 成员          | 系统内部拥有独立视角、记忆或角色的意识单元。               |
-| [Alterhuman](entries/系统角色与类型/Alterhuman.md)                                        | 特殊认同        | 泛指自我认同超出传统人类类别的社群概念，用于讨论多样身份体验。      |
-| [ANP-EP](<entries/系统体验与机制/Apparently-Normal-Part-Emotional-Part-Model.md>)                                     | ANP-EP 模型   | 描述创伤背景下“表面正常部分”与“情绪部分”互动的临床框架。       |
-| [ASD](entries/诊断与临床/Autism-Spectrum-Disorder.md)                                                | 孤独症谱系       | 指神经多样性谱系的统称，常用于共病或支持需求的讨论。           |
-| [ADHD](entries/诊断与临床/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)                                            | 注意缺陷多动障碍    | 涉及注意调节、执行功能与冲动控制困难的神经发育状况。           |
-| [Anxiety](entries/诊断与临床/Anxiety.md)                                             | 焦虑          | 持续的担忧、警觉与自主神经反应；超出情境需求时可能发展为焦虑障碍。     |
-| [Autopilot](entries/系统体验与机制/Autopilot.md)                                         | 自动驾驶        | 形容成员依照习惯自动处理事务、前台意识参与度较低的状态。         |
-| [Back / Being Back](entries/系统体验与机制/Back-Being-Back.md)                                   | 后台          | 不在前台掌控身体、转入内在活动或休息的成员状态。             |
-| [Bias](entries/系统体验与机制/Bias.md)                                                | 偏重          | 描述成员或系统在决策时对特定观点、情绪或记忆的倾向。           |
-| [Bipolar Disorders](entries/诊断与临床/Bipolar-Disorders.md)                             | 双相障碍       | 以躁狂/轻躁狂与抑郁发作为特征的情感障碍谱系，需要长期情绪稳定策略。 |
-| [Blending](entries/系统角色与类型/Blending.md)                                            | 混合          | 指多位成员的意识界限暂时模糊、体验互相渗透的情况。            |
-| [Created](entries/系统角色与类型/Emmengard-Classification.md#创造型created)                    | 创造型         | 埃蒙加德分类法标签之一，指成员通过图帕、系魂或角色构建等方式主动培育。 |
-| [Body Ownership](entries/系统体验与机制/Body-Ownership.md)                                    | 躯体认同        | 用于讨论成员对身体控制权与认同感的差异与变化。              |
-| [Borderline Personality Disorder，BPD](entries/诊断与临床/Borderline-Personality-Disorder-BPD.md)              | 边缘性人格障碍     | 以情绪调节、人际关系与自我形象不稳定为特征的人格模式。          |
-| [Co-consciousness](entries/系统体验与机制/Co-Consciousness.md)                                  | 意识共存        | 两位及以上成员同时在前台共同处理任务。                  |
-| [Co-fronting](entries/系统体验与机制/Co-Fronting.md)                                        | 共前台         | 描述多位成员同时在前台协作掌控身体的状态。                |
-| [Consciousness Modification](entries/系统体验与机制/Consciousness-Modification.md)                        | 意识修改        | 指通过练习调整觉察、边界或前台访问方式的技巧。              |
-| [Core](entries/系统角色与类型/Core.md)                                                | 核心          | 常指被视为最贴近系统原初身份或价值观的成员或结构。            |
-| [Caregiver](entries/系统角色与类型/Caregiver.md)                                      | 照顾者        | 负责情感支持与养育性照料，协助维持系统稳定。              |
-| [Emmengard Classification](entries/系统角色与类型/Emmengard-Classification.md)          | 埃蒙加德分类法    | 社群自我认同框架，依据系统形成来源与发展路径划分标签。          |
-| [CPTSD](entries/诊断与临床/CPTSD.md)                                         | 复杂性创伤后应激障碍  | 针对长期复杂创伤影响的诊断框架，强调持续性安全与支持需求。        |
-| [Depersonalization](entries/系统体验与机制/Depersonalization.md)                                  | 非我感         | 描述对自我或身体产生疏离、陌生感的现象。                 |
-| [Depersonalization/Derealization Disorder，DPDR](entries/诊断与临床/Depersonalization-Derealization-Disorder-DPDR.md) | 人格解体/现实解体障碍 | 临床诊断，涵盖非我感与非真实感持续困扰日常功能的情况。          |
-| [Depressive Disorders](entries/诊断与临床/Depressive-Disorders.md)                                | 抑郁障碍        | 泛指以持续情绪低落、兴趣缺失与认知改变为核心的障碍。           |
-| [DID](entries/诊断与临床/DID.md)                                              | 解离性身份障碍     | 以多个身份状态轮换控制与解离性失忆为核心的创伤相关解离障碍。             |
-| [Dissociation](entries/系统体验与机制/Dissociation.md)                                        | 解离          | 消歧义词条，指向功能性分离与病理性解离两种语境。              |
-| [Functional Dissociation](entries/系统体验与机制/Functional-Dissociation.md)                  | 功能性分离        | 描述日常多任务或注意调节中的适应性认知分离。              |
-| [Pathological Dissociation](entries/诊断与临床/Pathological-Dissociation.md)                  | 病理性解离        | 创伤相关的持续性整合失败，属于解离性障碍核心症状。          |
-| [Delirium](entries/诊断与临床/Delirium.md)                                                  | 谵妄          | 急性注意与意识混乱的状态，常伴定向障碍与安全风险，需要及时处理躯体诱因。 |
-| [Disorientation](entries/诊断与临床/Disorientation.md)                                     | 定向障碍        | 指无法辨识时间、地点、人物或自我身份的状态，常提示谵妄或其他认知障碍。 |
-| [Dissociative Amnesia](entries/诊断与临床/Dissociative-Amnesia-DA.md)                               | 解离性遗忘       | 指无法回忆重要个人信息的解离症状，常与创伤事件关联。           |
-| [Exomemory](entries/系统体验与机制/Exomemory.md)                                         | 独有记忆        | 仅对特定成员可访问、对其他成员呈现空白的记忆集合。            |
-| [Projection](entries/系统体验与机制/Projection.md)                                 | 投影          | 将成员的形象、感受或存在感延伸到现实环境的体验，是连接内视与外部互动的桥梁。     |
-| [Visualization / Imagination](entries/系统体验与机制/Visualization-Imagination.md) | 内视          | 在内心空间中“看到”或感知成员的练习，常作为与系统成员互动的基础阶段。         |
-| [External Projection](entries/系统体验与机制/External-Projection.md)                                | 外投射         | 社群中常与投影互换，强调将意识感知放置在现实空间的具体做法或体验描述。       |
-| [Fauxmain](entries/系统角色与类型/Fauxmain.md)                                           | 伪主体         | 指被误认为主要前台但并非真正宿主的成员角色。               |
-| [Flashback](entries/诊断与临床/Flashback.md)                                             | 闪回          | 创伤记忆以感官或情绪形式突然重现、难以控制的体验。            |
-| [Fragment](entries/系统角色与类型/Fragment.md)                                            | 碎片          | 用于描述功能或人格特质高度局限、结构较小的意识片段。           |
-| [Mixed](entries/系统角色与类型/Emmengard-Classification.md#混合型mixed)                        | 混合型         | 埃蒙加德分类法标签之一，指系统成员来源多样，兼具创伤与主动构建等成因。 |
-| [Front / Fronting](entries/系统体验与机制/Front-Fronting.md)                                    | 前台          | 当前与外界互动、控制身体的成员状态。                   |
-| [Fusion](entries/系统体验与机制/Fusion.md)                                              | 融合          | 形容两个或多个成员长期合并为单一身份体验的过程。             |
-| [Gatekeeper](entries/系统角色与类型/Gatekeeper.md)                                      | 守门人         | 管理前台访问、记忆共享与安全边界的权限角色，强调风险筛选与协作。 |
-| [Grounding](entries/实践与支持/Grounding.md)                                             | 接地          | 指帮助回到当下、缓解解离或焦虑的实用技巧。                |
-| [Head Pressure](entries/系统体验与机制/Head-Pressure.md)                                       | 头压          | 社群用于描述前台转换或内在活动伴随的头部紧张压迫感。           |
-| [Headspace / Inner World](entries/系统体验与机制/Headspace-Inner-World.md)                           | 内部空间、幻境、里空间 | 系统成员在内在世界中互动、聚会或构建场景的心象空间。           |
-| [Host](entries/系统角色与类型/Host.md)                                                | 宿主          | 常指最常出现在前台、负责外部生活事务的成员。               |
-| [Iatrogenic System](entries/系统角色与类型/Iatrogenic-System.md)                                | 医源型系统       | 指被认为因医疗、治疗或外部干预而形成或强化的系统。            |
-| [Imaginary Companion](entries/系统角色与类型/Imaginary-Companion.md)                            | 幻想伙伴        | 儿童常见的虚构朋友概念，需与图帕及系统成员区分。             |
-| [Independence](entries/系统体验与机制/Independence.md)                                       | 独立性         | 讨论成员在决策、情绪与生活功能上的自主程度。               |
-| [Integration](entries/系统体验与机制/Integration.md)                                         | 整合          | 强调提升成员协作、记忆连贯与功能稳定的长期目标。             |
-| [Internal Self Helper](entries/系统角色与类型/Internal-Self-Helper-ISH.md)                             | 内部自助者       | 在系统内承担辅导、调解与信息整合职责的成员原型。             |
-| [Intrusive Thoughts](entries/系统体验与机制/Intrusive-Thoughts.md)                               | 侵入性思维       | 描述突入意识、常伴焦虑或创伤主题的非自愿念头。              |
-| [Iteration](entries/系统体验与机制/Iteration.md)                                           | 迭代          | 用于记录系统内部的变更周期、角色调整或策略试验。             |
-| [Little / Child Part](entries/系统角色与类型/Little.md)                       | 小孩意识体       | 以童年视角感知世界、需要安全照护的成员。           |
-| [Lilith（《不/存在的你，和我》）](entries/虚拟角色与文学影视作品/Nonexistent-You-And-Me-Tulpa-Lilith.md) | 莉莉丝         | 独立游戏中的虚拟同伴角色，被社群视作 tulpa 象征，强调与玩家协商信任与边界。 |
-| [Main](entries/系统角色与类型/Main.md)                                                | 主体          | 社群常用来表示负责主要日常事务或决策的成员。               |
-| [Mania](entries/诊断与临床/Mania.md)                                       | 躁狂          | 情绪和能量显著高涨、睡眠需求减少、冲动决定或危险行为的状态。       |
-| [Meditation](entries/实践与支持/Meditation.md)                                            | 冥想          | 通过专注训练提升觉察、调节情绪与稳定前台状态的实践。           |
-| [Memory Holder](entries/系统角色与类型/Memory-Holder.md)                               | 记忆持有者       | 保管特定记忆或创伤片段的成员，需与治疗安全策略搭配。       |
-| [Memory Shielding](entries/系统体验与机制/Memory-Shielding.md)                                  | 记忆屏蔽        | 指成员为保护他人而限制或分隔特定记忆访问的机制。             |
-| [NPD](entries/诊断与临床/Narcissistic-Personality-Disorder-NPD.md)                                              | 自恋型人格障碍     | 以夸大、自我关注与共情困难为主要特征的人格模式。             |
-| [OCD](entries/诊断与临床/OCD.md)                                                  | 强迫症         | 以反复出现的强迫思维与强迫行为循环为核心特征的状态。           |
-| [OSDD](entries/诊断与临床/OSDD.md)                                           | 其他特定解离性障碍   | 涵盖未达到 DID 标准但存在显著身份或记忆分离的诊断类别。       |
-| [Original](entries/系统角色与类型/Original.md)                                  | 初始          | 指系统最早出现或被视为原始自我的成员，可能与宿主不同。     |
-| [Partial Dissociative Identity Disorder](entries/诊断与临床/Partial-Dissociative-Identity-Disorder-PDID.md)         | 部分解离性身份障碍   | 描述部分身份保持前台控制、仍保留连续意识体验的解离表现。         |
-| [Permissions](entries/系统体验与机制/Permissions.md)                                         | 权限          | 涉及系统内部对信息、前台或资源使用的授权规则。              |
-| [Persecutor](entries/系统角色与类型/Persecutor.md)                                | 迫害者        | 以防御为动机却可能采取敌对或自毁行为的成员。        |
-| [Performer / Executive](entries/系统角色与类型/Performer-Executive.md)             | 执行者        | 负责完成任务、管理外部事务的高功能成员。        |
-| [Persona](entries/系统角色与类型/Persona.md)                                           | 人格面具        | 指为特定情境塑造的社交或功能性面向。                   |
-| [Protector](entries/系统角色与类型/Protector.md)                                  | 保护者        | 聚焦安全与风险管理的成员，可分为内部与外部保护。      |
-| [Spontaneous](entries/系统角色与类型/Spontaneous.md)           | 自发型         | 埃蒙加德分类法标签之一，指系统自然显现或源自灵性、认知演化过程。    |
-| [Plurality](entries/系统体验与机制/Plurality.md)                                         | 多意识体        | 概括多个成员共享一具身体、协作生活的存在形态。              |
-| [Plurality Basics](entries/Plurality-Basics.md)                              | 多重意识体基础     | 面向新人介绍多意识体概念、术语与安全实践的入门资料。           |
-| [Polyfragmented](entries/系统角色与类型/Polyfragmented.md)                                    | 超级破碎        | 指拥有极多成员或碎片、结构高度复杂的系统。                |
-| [PTSD](entries/诊断与临床/PTSD.md)                                             | 创伤后应激障碍     | 创伤后以警觉性提高、回避与再体验等症状为主的障碍。            |
-| [Reconstruction](entries/系统体验与机制/Reconstruction.md)                                      | 重构          | 描述重建系统结构、角色或记忆架构的有意过程。               |
-| [Regression in Psychology](entries/系统体验与机制/Regression-In-Psychology.md)                            | 退行          | 指在压力下回到较早发展阶段的应对方式。                  |
-| [Schizophrenia](entries/诊断与临床/Schizophrenia-SC.md)                                      | 精神分裂症       | 以思维、感知与情感失调为核心的精神病性障碍。               |
-| [Sense of Presence](entries/系统体验与机制/Sense-Of-Presence.md)                                  | 存在感         | 讨论即便成员不在前台仍能感知其陪伴与互动的主观体验。           |
-| [Sequestration](entries/系统体验与机制/Sequestration.md)                                       | 封存          | 用于说明通过隔离记忆或情绪来维持功能的策略。               |
-| [Servitor](entries/系统角色与类型/Servitor.md)                                            | 傀儡          | 源于魔法或心理实践中，通过意念构建以执行任务的实体概念。         |
-| [SSD](entries/诊断与临床/Somatic-Symptom-Disorder-SSD.md)                                                | 躯体化障碍       | 聚焦躯体症状造成困扰并影响生活功能的诊断类别。              |
-| [Soulbond](entries/系统角色与类型/Soulbond.md)                                            | 系魂          | 描述与虚构角色或外部实体形成稳定互惠联系的成员或关系。          |
-| [Stress Response](entries/系统体验与机制/Stress-Response.md)                                   | 应激反应        | 概括身心对压力事件的即时生理与心理反应。                 |
-| [Switch](entries/系统体验与机制/Switch.md)                                              | 切换          | 从一位成员过渡到另一位成员执掌前台的过程。                |
-| [System](entries/系统体验与机制/System.md)                                              | 系统          | 指拥有多个成员的整体个体，强调为一个协作的身份集合。           |
-| [System Roles](entries/系统角色与类型/System-Roles.md)                             | 人格职能        | 概括系统成员常见职能类别及其协作方式。           |
-| [Unknown](entries/系统角色与类型/Emmengard-Classification.md#未知型unknown)                  | 未知型         | 埃蒙加德分类法标签之一，指系统暂未掌握自身形成来源或仍在探索。    |
-| [Trauma](entries/诊断与临床/Trauma.md)                                                | 创伤          | 指超出个体当时应对能力的威胁性经历及其后效。               |
-| [Trigger](entries/系统体验与机制/Trigger.md)                                             | 触发          | 引发强烈情绪、记忆或症状反应的内外部线索，需要提前识别并准备应对策略。  |
-| [Tulpa](entries/系统角色与类型/Tulpa.md)                                            | 图帕、托帕       | 通过有意想象与练习培育出的自主意识伙伴，与系统成员共享身体协作。     |
-| [Teen Part](entries/系统角色与类型/Teen.md)                                   | 青少年意识体      | 呈现青春期特征、关注独立与探索的成员。            |
-| [Tulpish](entries/系统体验与机制/Tulpish.md)                                             | T 语         | 指图帕或成员在内部交流时使用的象征化、非语音沟通方式。          |
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [Plurality Basics](entries/Plurality-Basics.md) | 多重意识体基础 | 面向新人介绍多意识体概念、术语与安全实践的入门资料。 |
+| [Plurality](entries/系统体验与机制/Plurality.md) | 多意识体 | 概括多个成员共享一具身体、协作生活的存在形态。 |
+| [System](entries/系统体验与机制/System.md) | 系统 | 指拥有多个成员的整体个体，强调为一个协作的身份集合。 |
+| [Switch](entries/系统体验与机制/Switch.md) | 切换 | 从一位成员过渡到另一位成员执掌前台的过程。 |
+| [Front / Fronting](entries/系统体验与机制/Front-Fronting.md) | 前台 | 当前与外界互动、控制身体的成员状态。 |
+| [Back / Being Back](entries/系统体验与机制/Back-Being-Back.md) | 后台 | 不在前台掌控身体、转入内在活动或休息的成员状态。 |
+| [Co-fronting](entries/系统体验与机制/Co-Fronting.md) | 共前台 | 描述多位成员同时在前台协作掌控身体的状态。 |
+| [Co-consciousness](entries/系统体验与机制/Co-Consciousness.md) | 意识共存 | 两位及以上成员同时在前台共同处理任务。 |
+| [Headspace / Inner World](entries/系统体验与机制/Headspace-Inner-World.md) | 内部空间、幻境、里空间 | 系统成员在内在世界中互动、聚会或构建场景的心象空间。 |
+| [Trigger](entries/系统体验与机制/Trigger.md) | 触发 | 引发强烈情绪、记忆或症状反应的内外部线索，需要提前识别并准备应对策略。 |
+
+## 实践与支持
+
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [Consciousness Modification](entries/系统体验与机制/Consciousness-Modification.md) | 意识修改 | 指通过练习调整觉察、边界或前台访问方式的技巧。 |
+| [Grounding](entries/实践与支持/Grounding.md) | 接地 | 指帮助回到当下、缓解解离或焦虑的实用技巧。 |
+| [Integration](entries/系统体验与机制/Integration.md) | 整合 | 强调提升成员协作、记忆连结与功能稳定的长期目标。 |
+| [Meditation](entries/实践与支持/Meditation.md) | 冥想 | 通过专注训练提升觉察、调节情绪与稳定前台状态的实践。 |
+| [Reconstruction](entries/系统体验与机制/Reconstruction.md) | 重构 | 描述重建系统结构、角色或记忆架构的有意过程。 |
+
+## 系统角色与类型
+
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [Admin](entries/系统角色与类型/Admin.md) | 管理者 | 系统中负责维护秩序、管理资源与协调事务的成员或团队角色。 |
+| [Alter](entries/系统角色与类型/Alter.md) | 成员 | 系统内部拥有独立视角、记忆或角色的意识单元。 |
+| [Caregiver](entries/系统角色与类型/Caregiver.md) | 照顾者 | 负责情感支持与养育性照料，协助维持系统稳定。 |
+| [Core](entries/系统角色与类型/Core.md) | 核心 | 常指被视为最贴近系统原初身份或价值观的成员或结构。 |
+| [Fauxmain](entries/系统角色与类型/Fauxmain.md) | 伪主体 | 指被误认为主要前台但并非真正宿主的成员角色。 |
+| [Fragment](entries/系统角色与类型/Fragment.md) | 碎片 | 用于描述功能或人格特质高度局限、结构较小的意识片段。 |
+| [Gatekeeper](entries/系统角色与类型/Gatekeeper.md) | 守门人 | 管理前台访问、记忆共享与安全边界的权限角色，强调风险筛选与协作。 |
+| [Host](entries/系统角色与类型/Host.md) | 宿主 | 常指最常出现在前台、负责外部生活事务的成员。 |
+| [Internal Self Helper](entries/系统角色与类型/Internal-Self-Helper-ISH.md) | 内部自助者 | 在系统内承担辅导、调解与信息整合职责的成员原型。 |
+| [Little / Child Part](entries/系统角色与类型/Little.md) | 小孩意识体 | 以童年视角感知世界、需要安全照护的成员。 |
+| [Main](entries/系统角色与类型/Main.md) | 主体 | 社群常用来表示负责主要日常事务或决策的成员。 |
+| [Memory Holder](entries/系统角色与类型/Memory-Holder.md) | 记忆持有者 | 保管特定记忆或创伤片段的成员，需与治疗安全策略搭配。 |
+| [Persecutor](entries/系统角色与类型/Persecutor.md) | 迫害者 | 以防御为动机却可能采取敌对或自毁行为的成员。 |
+| [Performer / Executive](entries/系统角色与类型/Performer-Executive.md) | 执行者 | 负责完成任务、管理外部事务的高功能成员。 |
+| [Persona](entries/系统角色与类型/Persona.md) | 人格面具 | 指为特定情境塑造的社交或功能性面向。 |
+| [Polyfragmented](entries/系统角色与类型/Polyfragmented.md) | 超级破碎 | 指拥有极多成员或碎片、结构高度复杂的系统。 |
+| [Protector](entries/系统角色与类型/Protector.md) | 保护者 | 聚焦安全与风险管理的成员，可分为内部与外部保护。 |
+| [System Roles](entries/系统角色与类型/System-Roles.md) | 人格职能 | 概括系统成员常见职能类别及其协作方式。 |
+| [Teen Part](entries/系统角色与类型/Teen.md) | 青少年意识体 | 呈现青春期特征、关注独立与探索的成员。 |
+
+## 系统体验与机制
+
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [Alcohol-Induced Dissociation](entries/系统体验与机制/Alcohol-Induced-Dissociation.md) | 醉酒解离 | 比喻解离发作时动作迟缓、语句含混等像醉酒的体验，并不一定涉及酒精摄入。 |
+| [Autopilot](entries/系统体验与机制/Autopilot.md) | 自动驾驶 | 形容成员依照习惯自动处理事务、前台意识参与度较低的状态。 |
+| [Bias](entries/系统体验与机制/Bias.md) | 偏重 | 描述成员或系统在决策时对特定观点、情绪或记忆的倾向。 |
+| [Body Ownership](entries/系统体验与机制/Body-Ownership.md) | 躯体认同 | 用于讨论成员对身体控制权与认同感的差异与变化。 |
+| [Blending](entries/系统角色与类型/Blending.md) | 混合 | 指多位成员的意识界限暂时模糊、体验互相渗透的情况。 |
+| [Depersonalization](entries/系统体验与机制/Depersonalization.md) | 非我感 | 描述对自我或身体产生疏离、陌生感的现象。 |
+| [Dissociation](entries/系统体验与机制/Dissociation.md) | 解离 | 消歧义词条，指向功能性分离与病理性解离两种语境。 |
+| [Exomemory](entries/系统体验与机制/Exomemory.md) | 独有记忆 | 仅对特定成员可访问、对其他成员呈现空白的记忆集合。 |
+| [External Projection](entries/系统体验与机制/External-Projection.md) | 外投射 | 社群中常与投影互换，强调将意识感知放置在现实空间的具体做法或体验描述。 |
+| [Fusion](entries/系统体验与机制/Fusion.md) | 融合 | 形容两个或多个成员长期合并为单一身份体验的过程。 |
+| [Head Pressure](entries/系统体验与机制/Head-Pressure.md) | 头压 | 社群用于描述前台转换或内在活动伴随的头部紧张压迫感。 |
+| [Independence](entries/系统体验与机制/Independence.md) | 独立性 | 讨论成员在决策、情绪与生活功能上的自主程度。 |
+| [Intrusive Thoughts](entries/系统体验与机制/Intrusive-Thoughts.md) | 侵入性思维 | 描述突入意识、常伴焦虑或创伤主题的非自愿念头。 |
+| [Iteration](entries/系统体验与机制/Iteration.md) | 迭代 | 用于记录系统内部的变更周期、角色调整或策略试验。 |
+| [Memory Shielding](entries/系统体验与机制/Memory-Shielding.md) | 记忆屏蔽 | 指成员为保护他人而限制或分隔特定记忆访问的机制。 |
+| [Permissions](entries/系统体验与机制/Permissions.md) | 权限 | 涉及系统内部对信息、前台或资源使用的授权规则。 |
+| [Projection](entries/系统体验与机制/Projection.md) | 投影 | 将成员的形象、感受或存在感延伸到现实环境的体验，是连接内视与外部互动的桥梁。 |
+| [Regression in Psychology](entries/系统体验与机制/Regression-In-Psychology.md) | 退行 | 指在压力下回到较早发展阶段的应对方式。 |
+| [Sequestration](entries/系统体验与机制/Sequestration.md) | 封存 | 用于说明通过隔离记忆或情绪来维持功能的策略。 |
+| [Sense of Presence](entries/系统体验与机制/Sense-Of-Presence.md) | 存在感 | 讨论即便成员不在前台仍能感知其陪伴与互动的主观体验。 |
+| [Stress Response](entries/系统体验与机制/Stress-Response.md) | 应激反应 | 概括身心对压力事件的即时生理与心理反应。 |
+| [Tulpish](entries/系统体验与机制/Tulpish.md) | T 语 | 指图帕或成员在内部交流时使用的象征化、非语音沟通方式。 |
+| [Visualization / Imagination](entries/系统体验与机制/Visualization-Imagination.md) | 内视 | 在内心空间中“看到”或感知成员的练习，常作为与系统成员互动的基础阶段。 |
+
+## 诊断与临床
+
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [ADHD](entries/诊断与临床/Attention-Deficit-Hyperactivity-Disorder-ADHD.md) | 注意缺陷多动障碍 | 涉及注意调节、执行功能与冲动控制困难的神经发育状况。 |
+| [Alexithymia](entries/诊断与临床/Alexithymia.md) | 述情障碍 | 描述难以识别、理解与表达情绪的体验，常与创伤或解离共现。 |
+| [Anxiety](entries/诊断与临床/Anxiety.md) | 焦虑 | 持续的担忧、警觉与自主神经反应；超出情境需求时可能发展为焦虑障碍。 |
+| [ASD](entries/诊断与临床/Autism-Spectrum-Disorder.md) | 孤独症谱系 | 指神经多样性谱系的统称，常用于共病或支持需求的讨论。 |
+| [Bipolar Disorders](entries/诊断与临床/Bipolar-Disorders.md) | 双相障碍 | 以躁狂/轻躁狂与抑郁发作为特征的情感障碍谱系，需要长期情绪稳定策略。 |
+| [Borderline Personality Disorder，BPD](entries/诊断与临床/Borderline-Personality-Disorder-BPD.md) | 边缘性人格障碍 | 以情绪调节、人际关系与自我形象不稳定为特征的人格模式。 |
+| [CPTSD](entries/诊断与临床/CPTSD.md) | 复杂性创伤后应激障碍 | 针对长期复杂创伤影响的诊断框架，强调持续性安全与支持需求。 |
+| [Delirium](entries/诊断与临床/Delirium.md) | 谵妄 | 急性注意与意识混乱的状态，常伴定向障碍与安全风险，需要及时处理躯体诱因。 |
+| [Depersonalization/Derealization Disorder，DPDR](entries/诊断与临床/Depersonalization-Derealization-Disorder-DPDR.md) | 人格解体/现实解体障碍 | 临床诊断，涵盖非我感与非真实感持续困扰日常功能的情况。 |
+| [Depressive Disorders](entries/诊断与临床/Depressive-Disorders.md) | 抑郁障碍 | 泛指以持续情绪低落、兴趣缺失与认知改变为核心的障碍。 |
+| [DID](entries/诊断与临床/DID.md) | 解离性身份障碍 | 以多个身份状态轮换控制与解离性失忆为核心的创伤相关解离障碍。 |
+| [Dissociative Amnesia](entries/诊断与临床/Dissociative-Amnesia-DA.md) | 解离性遗忘 | 指无法回忆重要个人信息的解离症状，常与创伤事件关联。 |
+| [Flashback](entries/诊断与临床/Flashback.md) | 闪回 | 创伤记忆以感官或情绪形式突然重现、难以控制的体验。 |
+| [Mania](entries/诊断与临床/Mania.md) | 躁狂 | 情绪和能量显著高涨、睡眠需求减少、冲动决定或危险行为的状态。 |
+| [NPD](entries/诊断与临床/Narcissistic-Personality-Disorder-NPD.md) | 自恋型人格障碍 | 以夸大、自我关注与共情困难为主要特征的人格模式。 |
+| [OCD](entries/诊断与临床/OCD.md) | 强迫症 | 以反复出现的强迫思维与强迫行为循环为核心特征的状态。 |
+| [OSDD](entries/诊断与临床/OSDD.md) | 其他特定解离性障碍 | 涵盖未达到 DID 标准但存在显著身份或记忆分离的诊断类别。 |
+| [Partial Dissociative Identity Disorder](entries/诊断与临床/Partial-Dissociative-Identity-Disorder-PDID.md) | 部分解离性身份障碍 | 描述部分身份保持前台控制、仍保留连续意识体验的解离表现。 |
+| [Pathological Dissociation](entries/诊断与临床/Pathological-Dissociation.md) | 病理性解离 | 创伤相关的持续性整合失败，属于解离性障碍核心症状。 |
+| [PTSD](entries/诊断与临床/PTSD.md) | 创伤后应激障碍 | 创伤后以警觉性提高、回避与再体验等症状为主的障碍。 |
+| [Schizophrenia](entries/诊断与临床/Schizophrenia-SC.md) | 精神分裂症 | 以思维、感知与情感失调为核心的精神病性障碍。 |
+| [SSD](entries/诊断与临床/Somatic-Symptom-Disorder-SSD.md) | 躯体化障碍 | 聚焦躯体症状造成困扰并影响生活功能的诊断类别。 |
+| [Trauma](entries/诊断与临床/Trauma.md) | 创伤 | 指超出个体当时应对能力的威胁性经历及其后效。 |
+
+## 相关概念与理论
+
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [Adaptive](entries/系统角色与类型/Adaptive.md) | 适应型 | 埃蒙加德分类法标签之一，强调系统因应对创伤或长期压力而形成。 |
+| [Alterhuman](entries/系统角色与类型/Alterhuman.md) | 特殊认同 | 泛指自我认同超出传统人类类别的社群概念，用于讨论多样身份体验。 |
+| [ANP-EP](<entries/系统体验与机制/Apparently-Normal-Part-Emotional-Part-Model.md>) | ANP-EP 模型 | 描述创伤背景下“表面正常部分”与“情绪部分”互动的临床框架。 |
+| [Created](entries/系统角色与类型/Emmengard-Classification.md#创造型created) | 创造型 | 埃蒙加德分类法标签之一，指成员通过图帕、系魂或角色构建等方式主动培育。 |
+| [Emmengard Classification](entries/系统角色与类型/Emmengard-Classification.md) | 埃蒙加德分类法 | 社群自我认同框架，依据系统形成来源与发展路径划分标签。 |
+| [Functional Dissociation](entries/系统体验与机制/Functional-Dissociation.md) | 功能性分离 | 描述日常多任务或注意调节中的适应性认知分离。 |
+| [Iatrogenic System](entries/系统角色与类型/Iatrogenic-System.md) | 医源型系统 | 指被认为因医疗、治疗或外部干预而形成或强化的系统。 |
+| [Imaginary Companion](entries/系统角色与类型/Imaginary-Companion.md) | 幻想伙伴 | 儿童常见的虚构朋友概念，需与图帕及系统成员区分。 |
+| [Mixed](entries/系统角色与类型/Emmengard-Classification.md#混合型mixed) | 混合型 | 埃蒙加德分类法标签之一，指系统成员来源多样，兼具创伤与主动构建等成因。 |
+| [Original](entries/系统角色与类型/Original.md) | 初始 | 指系统最早出现或被视为原始自我的成员，可能与宿主不同。 |
+| [Servitor](entries/系统角色与类型/Servitor.md) | 傀儡 | 源于魔法或心理实践中，通过意念构建以执行任务的实体概念。 |
+| [Soulbond](entries/系统角色与类型/Soulbond.md) | 系魂 | 描述与虚构角色或外部实体形成稳定互惠联系的成员或关系。 |
+| [Spontaneous](entries/系统角色与类型/Spontaneous.md) | 自发型 | 埃蒙加德分类法标签之一，指系统自然显现或源自灵性、认知演化过程。 |
+| [Tulpa](entries/系统角色与类型/Tulpa.md) | 图帕、托帕 | 通过有意想象与练习培育出的自主意识伙伴，与系统成员共享身体协作。 |
+| [Unknown](entries/系统角色与类型/Emmengard-Classification.md#未知型unknown) | 未知型 | 埃蒙加德分类法标签之一，指系统暂未掌握自身形成来源或仍在探索。 |
+
+## 其他
+
+| 术语 | 中文参考译名 | 社群用法/备注 |
+| --- | --- | --- |
+| [Lilith（《不/存在的你，和我》）](entries/虚拟角色与文学影视作品/Nonexistent-You-And-Me-Tulpa-Lilith.md) | 莉莉丝 | 独立游戏中的虚拟同伴角色，被社群视作 tulpa 象征，强调与玩家协商信任与边界。 |


### PR DESCRIPTION
## Summary
- 拆分 `Glossary.md` 中的术语表结构，按照常用术语、实践与支持、系统角色与类型等分类重新整理条目
- 调整表格内容与说明，使术语与 `index.md` 的目录分类保持一致并改善可读性

## Testing
- python tools/fix_md.py

------
https://chatgpt.com/codex/tasks/task_e_68df87d38360833390aac033185b7661