### PR TITLE
fix: 处理标签候选类型转换

### DIFF
--- a/tools/retag_and_related.py
+++ b/tools/retag_and_related.py
@@ -450,8 +450,12 @@ def extract_synonym_line(line: str) -> Iterable[str]:
 def collect_candidates(post: frontmatter.Post) -> Dict[str, float]:
     candidates: Dict[str, float] = defaultdict(float)
 
-    def add_candidate(raw: str, weight: float = 1.0) -> None:
-        raw = (raw or "").strip()
+    def add_candidate(raw: object, weight: float = 1.0) -> None:
+        if raw is None:
+            return
+        if not isinstance(raw, str):
+            raw = str(raw)
+        raw = raw.strip()
         if not raw:
             return
         if "#" in raw:


### PR DESCRIPTION
## Summary
- 修正 `tools/retag_and_related.py` 在收集标签候选时的类型处理，确保非字符串元数据不会引发异常
- 统一对候选值进行字符串化与空值过滤，保证标签提取流程稳定

## Testing
- python tools/retag_and_related.py

------
https://chatgpt.com/codex/tasks/task_e_68e056f8835c8333a71c8775ab2af63c