### PR TITLE
chore: 调整本地预览脚本默认使用 Python 服务器

### DIFF
--- a/Main_Page.html
+++ b/Main_Page.html
@@ -162,6 +162,7 @@
       <h2>核心板块速览</h2>
       <div class="badge-grid">
         <span class="badge">诊断与临床</span>
+        <span class="badge">心理学理论</span>
         <span class="badge">系统角色与类型</span>
         <span class="badge">系统体验与机制</span>
         <span class="badge">实践与支持</span>
@@ -169,6 +170,7 @@
       </div>
       <ul>
         <li><strong>诊断与临床：</strong>聚焦解离障碍、创伤后应激障碍、人格障碍等相关主题。</li>
+        <li><strong>心理学理论：</strong>整理依恋理论、情绪调节、防御性解离、动机理论等概念，提供理解系统运作的理论基础。</li>
         <li><strong>系统角色与类型：</strong>梳理成员角色定位、形成方式与协作方法。</li>
         <li><strong>系统体验与机制：</strong>讨论切换、共识、内部空间等机制。</li>
         <li><strong>实践与支持：</strong>整理冥想、接地等实务操作与同伴支持工具。</li>

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -8,7 +8,7 @@
 | --- | --- | --- |
 | `tools/fix_md.py` | 批量修复 Markdown 常见 Lint 问题，涵盖行尾空格、标题前后空行、围栏语言补全等 | `python tools/fix_md.py` 或 `python tools/fix_md.py --dry-run` |
 | `tools/check_links.py` | 扫描 Markdown 文档中疑似内部链接写法，禁止 `./`、`../` 等相对路径 | `python tools/check_links.py --root .`，必要时配合 `--whitelist` |
-| `tools/docs_preview.py` | 本地预览辅助：优先尝试 `docsify-cli`，失败时回退 `python -m http.server` | `python tools/docs_preview.py --port 4173`（可用 `--wait` 调整检测时间） |
+| `tools/docs_preview.py` | 本地预览辅助：默认启动 `python -m http.server`，可选 `--docsify` 启用 docsify-cli | `python tools/docs_preview.py --port 4173`（启用 docsify 时追加 `--docsify`） |
 | `tools/gen_changelog_by_tags.py` | 按 Git 标签时间顺序生成 `changelog.md` 并按提交类型分组 | `python tools/gen_changelog_by_tags.py --output changelog.md`，可加 `--latest-only`/`--latest-to-head` |
 | `tools/pdf_export/` | Pandoc 驱动的整站 PDF 导出工具，支持封面、忽略列表与中文字体 | `python tools/pdf_export/export_to_pdf.py` 或 `python -m pdf_export` |
 | `tools/gen-validation-report.py` | 校验词条结构并生成 `docs/VALIDATION_REPORT.md` | `python tools/gen-validation-report.py` |


### PR DESCRIPTION
## 动机
- 解决自动化脚本启动 docsify 预览时端口与提示不一致的问题，统一改用 Python 静态服务器

## 主要变更
- 更新 `tools/docs_preview.py`，默认直接启动 `python -m http.server 4173`，并通过 `--docsify` 参数提供可选的 docsify-cli 预览
- 同步调整 `docs/tools/README.md` 的脚本说明与示例用法，提示新增参数

## 风险与注意
- 若需使用 docsify-cli，请显式追加 `--docsify`，同时可通过 `--wait` 调整启动检测时长

## 相关条目
- docs/tools/README.md
- tools/docs_preview.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ffb8267c8333b10ce4f45f93374a