### PR TITLE
fix: 调整搜索配置以使用默认分词

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,7 +195,6 @@ plugins:
       lang:
         - zh
         - en
-      jieba_dict_user: jieba_userdict.txt
 
   - tags
 


### PR DESCRIPTION
## Summary
- 移除 MkDocs search 插件的用户词典配置，恢复默认结巴词典以避免单字搜索命中缺失

## Testing
- 未运行测试（配置改动）

------
https://chatgpt.com/codex/tasks/task_e_68e6697c0d3c833381ffc0b404fe46c8