### PR TITLE
修复 Giscus 评论在未找到讨论时的处理逻辑

### DIFF
--- a/docs/assets/giscus-loader.js
+++ b/docs/assets/giscus-loader.js
@@ -243,10 +243,24 @@
     }
 
     if (payload.error) {
-      let detail = payload.error;
+      const rawDetail = typeof payload.error === 'string'
+        ? payload.error
+        : '';
+
+      if (rawDetail && /discussion not found/i.test(rawDetail)) {
+        // 当尚未创建讨论主题时，Giscus 会返回此提示。
+        // 允许 Giscus 在 iframe 内呈现“创建讨论”界面，因此不触发回退。
+        hideFallback(root);
+        return;
+      }
+
+      let detail = rawDetail || payload.error;
       if (typeof detail === 'string' && /not installed/i.test(detail)) {
         detail = '尚未安装 Giscus 应用或未启用 Discussions 分类。';
+      } else if (typeof detail === 'string' && /bad credentials/i.test(detail)) {
+        detail = 'GitHub 凭证无效，请检查 Cloudflare Pages 或构建环境的访问令牌配置。';
       }
+
       showFallback(root, detail);
       cleanup();
       return;


### PR DESCRIPTION
## 摘要
- 调整 giscus-loader 的错误处理逻辑，避免在 "Discussion not found" 情况下误触发回退提示。
- 保留 Giscus iframe 以便用户按需创建新讨论，并补充常见错误提示语。

## 测试
- 未运行自动化测试（前端脚本改动）。

------
https://chatgpt.com/codex/tasks/task_e_68e9cd496110833394678f06ed060a50