### PR TITLE
调整搜索插件最小搜索长度

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,7 @@ plugins:
       lang:
         - zh
         - en
+      min_search_length: 2
 
   - tags
 


### PR DESCRIPTION
## Summary
- 为内置搜索插件新增 `min_search_length: 2` 配置，支持两个字符起搜

## Testing
- 未运行测试（配置项调整）

------
https://chatgpt.com/codex/tasks/task_e_68ea735a903c833399fe7339f5295f21