### PR TITLE
修复中文搜索因零宽空格无法匹配的问题

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,9 @@ repo_name: mps-team-cn/Multiple_personality_system_wiki
 copyright: Copyright &copy; 2024-2025 Multiple Personality System Wiki
 edit_uri: edit/main/docs/
 
+hooks:
+  - tools/mkdocs_hooks.py
+
 theme:
   name: material
   language: zh
@@ -147,7 +150,7 @@ extra_css:
 extra_javascript:
   - assets/extra.js
   - assets/giscus-loader.js  # Giscus 评论加载器
-  - assets/search-phrase-default.js #搜索优化js
+  - assets/search-phrase-default.js # 搜索短语自动加引号
 
 
 # Markdown 扩展

--- a/tools/mkdocs_hooks.py
+++ b/tools/mkdocs_hooks.py
@@ -1,0 +1,43 @@
+"""MkDocs 构建钩子：清理搜索索引中的零宽空格，避免中文搜索失效。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+ZERO_WIDTH_SPACE = "\u200b"
+
+
+def _strip_zero_width(value: str) -> str:
+    """移除文本中的零宽空格，保持其余字符不变。"""
+    return value.replace(ZERO_WIDTH_SPACE, "")
+
+
+def on_post_build(config: Dict[str, Any]) -> None:
+    """在构建完成后清理搜索索引文本。"""
+    site_dir = Path(config.get("site_dir", ""))
+    search_index = site_dir / "search" / "search_index.json"
+
+    if not search_index.exists():
+        return
+
+    data = json.loads(search_index.read_text(encoding="utf-8"))
+    changed = False
+
+    for doc in data.get("docs", []):
+        for key in ("title", "text"):
+            value = doc.get(key)
+            if not value:
+                continue
+
+            cleaned = _strip_zero_width(value)
+            if cleaned != value:
+                doc[key] = cleaned
+                changed = True
+
+    if changed:
+        search_index.write_text(
+            json.dumps(data, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )


### PR DESCRIPTION
## 概述
- 在 MkDocs 构建钩子中移除 search_index.json 内的零宽空格，确保中文词条能够被 Lunr 正常索引
- 重新注册搜索优化脚本并在配置中启用钩子文件，保证构建阶段自动修复索引

## 测试
- `mkdocs build`
- `mkdocs serve -a 0.0.0.0:8001`（通过 Playwright 手动搜索“弦羽理论”验证结果）

------
https://chatgpt.com/codex/tasks/task_e_68ec0e30a4508333aab238ced85c5d3b