### PR TITLE
chore: 移除过时的 PYTHON_VERSION 环境变量配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ docsify serve .
 
 Build command: bash .cfpages-build.sh
 Build output directory: site
-Environment variables: PYTHON_VERSION=3.11
+# 环境变量：无需配置（使用 Cloudflare Pages 默认 Python 3.13.3）
 ```
 
 **在线地址** ：<https://wiki.mpsteam.cn/>

--- a/docs/dev/CLOUDFLARE_PAGES.md
+++ b/docs/dev/CLOUDFLARE_PAGES.md
@@ -26,10 +26,10 @@
 
 #### 环境变量
 
-可选的环境变量:
+~~可选的环境变量~~（已废弃，Cloudflare Pages 默认提供 Python 3.13.3）:
 
 ```text
-PYTHON_VERSION=3.11
+# PYTHON_VERSION=3.11  # 不再需要，使用系统默认版本
 ```
 
 ### 3. 高级设置


### PR DESCRIPTION
## 概述

移除 Cloudflare Pages 部署配置中过时的 `PYTHON_VERSION` 环境变量。

## 变更内容

- 📝 标记 `CLOUDFLARE_PAGES.md` 中的 `PYTHON_VERSION=3.11` 配置为已废弃
- 📝 更新 `README.md` 构建配置说明，移除环境变量配置
- 📋 添加说明：Cloudflare Pages 默认提供 Python 3.13.3

## 变更原因

1. **Cloudflare Pages 官方支持**：根据官方文档，当前默认 Python 版本为 3.13.3
2. **简化配置**：无需额外指定 Python 版本，减少配置复杂度
3. **提升部署速度**：使用默认版本可能加快构建速度
4. **版本更新**：Python 3.13.3 > 3.11，使用更新的版本

## 影响范围

- ✅ 不影响现有构建流程
- ✅ 不需要修改 `.cfpages-build.sh` 脚本
- ✅ 仅更新文档说明

## 后续操作

合并后建议在 Cloudflare Pages 控制台中：
1. 进入项目的 **Settings** → **Environment variables**
2. 删除 `PYTHON_VERSION` 环境变量（如果存在）
3. 触发一次重新部署验证构建正常

## 相关文件

- [README.md](README.md#L350)
- [CLOUDFLARE_PAGES.md](docs/dev/CLOUDFLARE_PAGES.md#L27-L33)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)