### PR TITLE
fix: 修复搜索同义词索引不支持字符串格式的问题

### DIFF
--- a/tools/mkdocs_hooks.py
+++ b/tools/mkdocs_hooks.py
@@ -20,7 +20,12 @@ def _strip_zero_width(value: str) -> str:
 
 
 def _extract_frontmatter_synonyms(file_path: Path) -> list[str]:
-    """从 Markdown 文件的 Frontmatter 中提取 synonyms 字段。"""
+    """从 Markdown 文件的 Frontmatter 中提取 synonyms 字段。
+
+    支持两种格式：
+    1. 列表格式: synonyms: [syn1, syn2, syn3]
+    2. 字符串格式: synonyms: syn1, syn2, syn3
+    """
     if not file_path.exists():
         return []
 
@@ -34,8 +39,15 @@ def _extract_frontmatter_synonyms(file_path: Path) -> list[str]:
     try:
         frontmatter = yaml.safe_load(match.group(1))
         synonyms = frontmatter.get("synonyms", [])
+
+        # 处理列表格式
         if isinstance(synonyms, list):
             return [str(s).strip() for s in synonyms if s]
+
+        # 处理字符串格式（逗号分隔）
+        if isinstance(synonyms, str):
+            return [s.strip() for s in synonyms.split(',') if s.strip()]
+
         return []
     except Exception:
         return []


### PR DESCRIPTION
## 问题描述

之前的提交（dfcfe983）尝试支持在搜索中索引 Frontmatter 的 `synonyms` 字段，但实际测试发现部分词条的同义词无法被搜索到。

## 根本原因

`_extract_frontmatter_synonyms()` 函数只处理了**列表格式**的 synonyms：

```yaml
synonyms:
  - 同义词1
  - 同义词2
```

但项目中部分词条（如 `Bias.md`）使用了**字符串格式**：

```yaml
synonyms: 同义词1, 同义词2, 同义词3
```

导致这些同义词无法被提取和注入到搜索索引中。

## 解决方案

在 `_extract_frontmatter_synonyms()` 中增加对字符串格式的支持：

- ✅ 如果 synonyms 是列表，按原逻辑处理
- ✅ 如果 synonyms 是字符串，按逗号分隔并处理
- ✅ 两种格式都会被正确提取并注入到搜索索引

## 测试验证

本地构建后验证：

- ✅ **Bias.md**（字符串格式）：4 个同义词全部注入成功
- ✅ **CPTSD.md**（列表格式）：5 个同义词全部注入成功
- ✅ 搜索索引正确包含所有同义词

## 影响范围

- 修改文件：`tools/mkdocs_hooks.py`
- 影响功能：搜索索引生成时的同义词提取
- 向下兼容：完全兼容现有列表格式，新增字符串格式支持

🤖 Generated with [Claude Code](https://claude.com/claude-code)