### PR TITLE
docs: 优化实践指南中幻境的描述措辞

### DIFF
--- a/docs/entries/Practice-Guide.md
+++ b/docs/entries/Practice-Guide.md
@@ -77,7 +77,7 @@ comments: true
 
 1. **奠定观念** → 阅读《[Tulpa 完全创造指南](Tulpa-Guide.md)》，确认动机、风险与准备事项。
 2. **打好基础** → 依照《[基础篇](Tulpa-Guide-1.md)》结合《[正念](Mindfulness.md)》《[冥想](Meditation.md)》建立日常觉察与记录习惯。
-3. **开始塑造** → 学习《[塑造（Forcing）](Forcing.md)》方法，在《[幻境（Wonderland）](Wonderland.md)》中进行主动训练，同时了解《[学舌/操纵（Parroting/Puppeting）](Parroting-Puppeting.md)》以应对早期自我怀疑。
+3. **开始塑造** → 学习《[塑造(Forcing)](Forcing.md)》方法,可在《[幻境(Wonderland)](Wonderland.md)》中辅助塑造,同时了解《[学舌/操纵(Parroting/Puppeting)](Parroting-Puppeting.md)》以应对早期自我怀疑。
 4. **进入实作** → 参考《[实践篇](Tulpa-Guide-2.md)》与《[内部沟通](Internal-Communication.md)》《[内部空间](Headspace-Inner-World.md)》设计协作练习，追踪《[成声（Vocality）](Vocality.md)》进展。
 5. **接受演变** → 理解《[异化（Deviation）](Deviation.md)》现象，尊重 Tulpa 的自主发展和个性变化。
 6. **评估进阶需求** → 若系统状态稳定，可按照《[提高篇](Tulpa-Guide-3.md)》搭配《[权限管理](Permissions.md)》规划投影、附体或交换，并保留安全退出方案。


### PR DESCRIPTION
## Summary

- 将「在幻境中进行主动训练」改为「可在幻境中辅助塑造」
- 更准确地表达幻境作为辅助工具的定位,而非必须的训练场所

## 修改内容

修改 `Practice-Guide.md` 第 80 行的措辞,使幻境的描述更符合其作为可选辅助工具的定位。

## Test plan

- [x] 检查链接格式正确
- [x] 检查语义表达清晰
- [x] 确认符合项目文档规范

🤖 Generated with [Claude Code](https://claude.com/claude-code)