### PR TITLE
feat: 为核心词条添加搜索权重配置

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,55 @@ updated: YYYY-MM-DD
     - 📚 导览文件：`*-Guide.md`（如 `Clinical-Diagnosis-Guide.md`）
     - 📑 索引文件：`*-Index.md`（如 `Tools-Index.md`）
 
+#### 🔍 搜索权重配置（可选）
+
+!!! tip "提升重要词条的搜索排名"
+    对于核心词条，可在 Frontmatter 中添加 `search.boost` 字段来提高搜索结果中的权重。
+
+**推荐的权重分级**：
+
+| 优先级 | 权重值 | 适用词条类型 | 示例 |
+|--------|--------|-------------|------|
+| **最高** | `2.0` | 诊断类疾病 | DID、OSDD、PTSD、CPTSD |
+| **高** | `1.8` | 核心概念与操作 | Alter、Tulpa、System、Switch、Grounding、Host、Dissociation、Trauma |
+| **中高** | `1.5` | 重要概念 | Multiple_Personality_System、Protector、Front/Fronting |
+| **默认** | `1.0`（无需设置） | 普通词条 | 其他所有词条 |
+
+**配置示例**：
+
+```yaml
+---
+title: 解离性身份障碍（DID）
+topic: 诊断与临床
+tags:
+  - 诊断与临床
+  - DID
+  - 多重意识体
+updated: 2025-01-15
+search:
+  boost: 2.0  # 最高优先级
+---
+```
+
+```yaml
+---
+title: 系统（System）
+topic: 系统运作
+tags:
+  - 系统运作
+  - 多重意识体
+updated: 2025-01-15
+search:
+  boost: 1.8  # 高优先级
+---
+```
+
+!!! warning "注意事项"
+    - ✅ 仅为**真正重要**的核心词条设置权重，避免滥用
+    - ✅ 权重值通常在 `1.0` - `2.0` 之间，不建议超过 `2.0`
+    - ✅ 大多数词条无需设置权重（默认 `1.0`）
+    - ⚠️ 修改权重后需重新构建站点才能生效
+
 #### ✨ 词条格式规范
 
 !!! tip "加粗内容格式"

--- a/docs/entries/Alter.md
+++ b/docs/entries/Alter.md
@@ -14,6 +14,8 @@ synonyms:
 
 - 成员
 
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/CPTSD.md
+++ b/docs/entries/CPTSD.md
@@ -18,6 +18,8 @@ synonyms:
 - CPTSD
 - fuzaxingchuangshanghouyingjizhangai
 
+search:
+  boost: 1.5
 comments: true
 ---
 

--- a/docs/entries/DID.md
+++ b/docs/entries/DID.md
@@ -10,6 +10,8 @@ topic: 诊断与临床
 description: 深入解析解离性身份障碍（DID）的诊断标准、临床表现与治疗方法。了解多重人格障碍的本质、创伤根源及康复路径，包含 ICD-11 与 DSM-5-TR 权威诊断标准
 title: 解离性身份障碍（Dissociative Identity Disorder，DID）
 updated: 2025-10-16
+search:
+  boost: 2.0
 comments: true
 ---
 

--- a/docs/entries/Dissociation.md
+++ b/docs/entries/Dissociation.md
@@ -11,6 +11,8 @@ topic: 系统运作
 description: 解离现象的全面解析：功能性分离、防御性解离与解离障碍的区别。理解从正常解离到病理性解离的连续谱，掌握解离体验的本质
 title: 解离（Dissociation）
 updated: 2025-10-14
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/Front-Fronting.md
+++ b/docs/entries/Front-Fronting.md
@@ -10,6 +10,8 @@ topic: 系统运作
 title: 前台（Front / Fronting）
 updated: 2025-10-17
 description: 定义前台/执掌、区分与切换/共前台/后台的边界，提供安全交接与前台治理范例、常见误解与参考资料。
+search:
+  boost: 1.5
 comments: true
 ---
 

--- a/docs/entries/Grounding.md
+++ b/docs/entries/Grounding.md
@@ -10,6 +10,8 @@ topic: 创伤与疗愈
 description: 接地（Grounding）技术完整指南：应对解离、焦虑与创伤触发的有效方法。学习感官觉察、身体定向等实用技巧，重建当下连接
 title: 接地（Grounding）
 updated: 2025-10-14
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/Host.md
+++ b/docs/entries/Host.md
@@ -10,6 +10,8 @@ topic: 角色与身份
 description: 宿主（Host）的定义、角色与挑战。理解主要控制身体的成员特征、宿主与其他成员的关系及宿主身份的动态性
 title: 宿主（Host）
 updated: 2025-10-14
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/Multiple_Personality_System.md
+++ b/docs/entries/Multiple_Personality_System.md
@@ -18,6 +18,8 @@ synonyms:
 - Plurality
 - duochong renge xitong
 
+search:
+  boost: 1.5
 comments: true
 ---
 

--- a/docs/entries/OSDD.md
+++ b/docs/entries/OSDD.md
@@ -11,6 +11,8 @@ topic: 诊断与临床
 description: 详解其他特定解离性障碍（OSDD）的诊断标准与临床特征。探讨部分 DID、非典型解离障碍的表现形式，理解不完全符合 DID 标准的解离性障碍
 title: 其他特定解离性障碍（OSDD）
 updated: 2025-10-14
+search:
+  boost: 2.0
 comments: true
 ---
 

--- a/docs/entries/PTSD.md
+++ b/docs/entries/PTSD.md
@@ -19,6 +19,8 @@ synonyms:
 - PTSD
 - chuangshanghouyingjizhangai
 
+search:
+  boost: 1.5
 comments: true
 ---
 

--- a/docs/entries/Protector.md
+++ b/docs/entries/Protector.md
@@ -10,6 +10,8 @@ topic: 角色与身份
 description: 保护者（Protector）成员的类型、功能与工作方式。了解保护性成员如何维护系统安全、应对威胁及其可能的过度保护模式
 title: 保护者（Protector）
 updated: 2025-10-16
+search:
+  boost: 1.5
 comments: true
 ---
 

--- a/docs/entries/Switch.md
+++ b/docs/entries/Switch.md
@@ -20,6 +20,8 @@ synonyms:
     - 接管（Takeover）
     - 前台更替
 
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/System.md
+++ b/docs/entries/System.md
@@ -10,6 +10,8 @@ topic: 系统运作
 description: 多意识体系统的完整定义与运作原理。了解系统成员、内部沟通、前台切换等核心概念，探索多重意识体的协作与管理机制
 title: 系统（System）
 updated: 2025-10-14
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/Trauma.md
+++ b/docs/entries/Trauma.md
@@ -17,6 +17,8 @@ synonyms:
 - Trauma
 - chuangshang
 
+search:
+  boost: 1.8
 comments: true
 ---
 

--- a/docs/entries/Tulpa.md
+++ b/docs/entries/Tulpa.md
@@ -10,6 +10,8 @@ topic: 角色与身份
 description: 全面了解 Tulpa（图帕）的创造原理、培育方法与实践指南。探索意识同伴的形成机制、与 DID 的区别及社群文化，包含系统化训练技巧
 title: 图帕（Tulpa）
 updated: 2025-10-14
+search:
+  boost: 1.8
 comments: true
 ---
 


### PR DESCRIPTION
## 📝 变更摘要

为 15 个核心词条添加搜索权重配置，提升站内搜索体验。同时更新 AGENTS.md 文档，补充搜索权重配置指南。

---

## 🎯 变更动机

当用户搜索关键词（如 DID、OSDD、Tulpa、Alter）时，这些核心词条应该优先显示在搜索结果中，提升信息获取效率。

---

## 📋 主要改动点

### 1. 词条搜索权重配置（15个核心词条）

#### 🔴 最高优先级 (boost: 2.0) - 诊断类疾病
- `DID.md` - 解离性身份障碍
- `OSDD.md` - 其他特定解离性障碍

#### 🟠 高优先级 (boost: 1.8) - 核心概念与操作
- `Alter.md` - 成员
- `Tulpa.md` - 图帕
- `System.md` - 系统
- `Switch.md` - 切换
- `Grounding.md` - 接地
- `Host.md` - 宿主
- `Dissociation.md` - 解离
- `Trauma.md` - 创伤

#### 🟡 中高优先级 (boost: 1.5) - 重要概念
- `Multiple_Personality_System.md` - 多意识体系统
- `PTSD.md` - 创伤后应激障碍
- `CPTSD.md` - 复杂性创伤后应激障碍
- `Protector.md` - 保护者
- `Front-Fronting.md` - 前台

### 2. 文档更新

**AGENTS.md** 新增"搜索权重配置"章节：
- ✅ 权重分级指南（2.0/1.8/1.5）
- ✅ 适用词条类型说明
- ✅ 配置示例代码
- ✅ 使用注意事项

---

## 🔧 技术实现

使用 MkDocs Material 的 `search` 插件 boosting 功能：

```yaml
---
title: 解离性身份障碍（DID）
search:
  boost: 2.0  # 提升搜索权重
---
```

---

## ⚠️ 潜在风险

- ✅ **无破坏性变更** - 仅添加可选的 Frontmatter 字段
- ✅ **向后兼容** - 不影响现有功能和已有词条
- ✅ **CI 自动维护** - 时间戳会在合并后自动更新
- ✅ **可逆操作** - 随时可删除 `search.boost` 字段恢复默认权重

---

## 📊 预期效果

**搜索 "DID"**：
- ✅ `DID.md` (boost: 2.0) 排在第一位
- ✅ 相关词条（OSDD、System）紧随其后

**搜索 "Tulpa"**：
- ✅ `Tulpa.md` (boost: 1.8) 优先显示
- ✅ 相关实践指南词条跟随

---

## ✅ 检查清单

- [x] 遵循 Conventional Commits 规范
- [x] 更新相关文档（AGENTS.md）
- [x] 权重分级合理，避免滥用
- [x] Frontmatter 格式正确
- [x] 提交信息清晰完整

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>