### PR TITLE
docs: 记忆屏蔽（Memory Shielding）条目修订：术语边界、Clinician’s Summary、法证警示、循证干预表述

### DIFF
--- a/docs/entries/Memory-Shielding.md
+++ b/docs/entries/Memory-Shielding.md
@@ -1,42 +1,58 @@
 ---
+title: 记忆屏蔽（Memory Shielding）
+topic: 系统运作
 tags:
 
-- 系统运作
-- 多重意识体
-- 解离
-- 创伤
+  - 系统运作
+  - 多重意识体
+  - 解离
+  - 创伤
 
-topic: 系统运作
-title: 记忆屏蔽（Memory Shielding）
+updated: 2025-10-19
+description: 记忆屏蔽是多意识体社群中的经验性术语，指身份间对特定记忆的访问限制。非 DSM-5-TR/ICD-11 正式术语；临床处置以稳定化与创伤加工整合为主。
+search:
+  boost: 1.4
 synonyms:
 
-    - Memory Shielding
-    - Amnesiacflux
-    - 屏蔽记忆
-    - 记忆隔离
-
-updated: 2025-10-18
+  - 记忆屏障
+  - 屏障记忆
+  - 屏蔽记忆
+  - 记忆隔离
+  - 记忆封存
+  - Memory Shielding
+  - Amnesiacflux
 comments: true
 ---
 
 # 记忆屏蔽（Memory Shielding）
 
+!!! info "术语状态｜社群/经验性术语"
+    本词条描述多意识体社群中的经验性现象，非《DSM-5-TR》或《ICD-11》中的正式诊断或编码用语。临床书写与法证文件中不应将“记忆屏蔽”作为诊断名词使用。
+
+!!! note "Clinician’s Summary（150–200 字）"
+    记忆屏蔽指系统内不同身份状态（identity state）间对特定记忆的访问限制，多见于创伤谱与[解离性身份障碍（DID）](DID.md)/[OSDD](OSDD.md)。常涉及状态依赖性记忆与防御性分隔。处置要点：先稳定化（接地、情绪调节），再在 [EMDR](Eye-Movement-Desensitization-Reprocessing-EMDR.md)/[CPT](Cognitive-Processing-Therapy-CPT.md)/[PE](Prolonged-Exposure-Therapy-PE.md) 等循证框架下促进创伤记忆加工与整合，非“解除屏蔽”。严禁诱导性技术与“恢复记忆”；法证情境须慎。
+
+!!! info "诊断与编码映射（背景提示）"
+    当需提及相关临床诊断时：DSM‑5‑TR：解离性身份障碍（DID）300.14（ICD‑10‑CM：F44.81）；ICD‑11：DID 6B64。本文所述“记忆屏蔽”不对应任何编码，仅为现象性描述。
+
 ## 定义
 
-**记忆屏蔽**（Memory Shielding）是指多重意识体系统中，个体或系统成员通过主动策略或被动机制限制特定记忆内容在不同身份之间的共享、访问与提取的现象。这一机制可能是有意识的保护性措施，也可能是创伤应激后的自动防御反应。
+本节概述“记忆屏蔽”的通用内涵与边界。
+
+**记忆屏蔽**（Memory Shielding）是指多重意识体系统中，个体或系统成员通过主动策略或被动机制，限制特定记忆在不同身份状态间的共享、访问与提取。其可作为保护性措施，也可表现为创伤后自动化的防御反应；不构成独立诊断。
 
 ### 核心特征
 
-记忆屏蔽作为多重系统中常见的记忆管理机制，具有以下特点：
+作为系统内常见的记忆管理现象，记忆屏蔽通常具备：
 
 1. **选择性遗忘**：特定记忆仅对部分身份可访问，其他身份无法回忆或仅有模糊印象
 2. **可逆性**：屏蔽程度可能随时间、安全感或治疗进展而变化
 3. **功能性目的**：通常服务于保护、稳定或维持系统运作的需要
-4. **与身份相关**：记忆的可访问性往往与身份角色、创伤距离或系统权限有关[^dsm5]
+4. **与身份相关**：记忆可访问性与身份角色、创伤距离或系统权限相关（见 DID/OSDD 标准）[^dsm5tr]
 
-### 类型分类
+### 类型分类（可扫读）
 
-根据形成机制和控制程度，记忆屏蔽可分为：
+按形成机制与控制程度，常见三型：
 
 **1. 主动屏蔽（Active Shielding）**
 
@@ -60,94 +76,83 @@ comments: true
 
 ## 机制与证据
 
-### 神经生物学基础
+概述当前证据：支持“身份/状态依赖的提取差异”的趋势存在，但研究样本量较小、范式异质，结果并非一致，应谨慎外推。
 
-研究显示，解离性身份障碍（DID）患者在身份切换时，大脑记忆相关区域呈现显著差异：
+### 神经影像与认知线索（证据有限）
 
-- **海马与杏仁核活动变化**：不同身份状态下，海马（负责记忆编码和提取）和杏仁核（情绪记忆处理）的活动模式存在差异，提示记忆检索受到身份依赖性调节[^schlumpf2014]
-- **前额叶控制功能**：功能性磁共振成像研究表明，记忆屏蔽可能涉及前额叶皮层对记忆提取的主动抑制
-- **状态依赖性记忆**：记忆的编码和提取可能与特定身份状态相关，类似于状态依赖性学习效应
+- 海马/杏仁核与前额叶：不同身份状态（identity state）下的活动模式可见差异，提示记忆检索受身份与情绪调节影响[^schlumpf2014]。
+- 状态依赖性记忆（SDM）：编码—提取依赖相似生理/情绪/认知状态，可能解释身份间访问差异。
+- 证据限定语：多为小样本、任务与对照不一，结论存在不一致，尚不足以推出特定“屏蔽中枢”。
 
-### 心理防御机制
+### 心理防御与功能目的（临床一致感较高）
 
-从创伤心理学视角，记忆屏蔽可视为一种高层次心理防御：
+- 保护性分隔：限制高负荷创伤记忆的闯入以维持功能与安全[^frey2019]。
+- 情绪调节与认知隔离：将记忆内容与情绪反应分离，减少压垮风险。
 
-- **保护性解离**：通过限制侵入性创伤回忆的访问，维持日常功能和心理稳定[^frey2019]
-- **情绪调节功能**：屏蔽高强度负性情绪记忆，避免压垮当前身份的承受能力
-- **认知隔离**：类似于心理防御机制中的"隔离"（Isolation），将记忆内容与情绪反应分离
+### 临床呈现（现象学）
 
-### 临床观察
-
-在临床实践中，记忆屏蔽表现为：
-
-- **身份间遗忘**：DID 诊断标准之一，不同身份对共同经历的回忆存在显著差异
-- **触发相关记忆泄漏**：在特定触发情境下，原本被屏蔽的记忆可能突然涌现
-- **功能性影响**：过度屏蔽可能导致时间丧失、日常生活连续性受损或决策困难
+- 身份间遗忘：符合 DID/OSDD 的身份相关记忆差异（见[解离障碍](Dissociative-Disorders.md)）。
+- 触发泄漏：在触发下出现碎片化回想或情绪/感官片段。
+- 功能影响：过度分隔导致时间丢失、连续性受损与决策困难。
 
 ## 鉴别
 
-记忆屏蔽需要与以下现象进行区分：
+先排除医学与物质因素，再区分解离相关现象与一般遗忘。
 
 ### 与正常遗忘的区别
 
 - **正常遗忘**：随时间自然衰退，影响所有身份，无明显身份间差异
 - **记忆屏蔽**：选择性地影响特定身份，其他身份可能保有完整记忆
 
-### 与解离性遗忘（DA）的关系
+### 与解离性遗忘（DA）与状态依赖性记忆（SDM）
 
-- **解离性遗忘**：广泛的记忆丧失，通常涉及创伤事件或特定时间段，可能影响所有身份[见[解离性遗忘（Dissociative Amnesia，DA）](Dissociative-Amnesia-DA.md)]
-- **记忆屏蔽**：更具针对性，特定记忆在系统内部分身份间不可访问，但其他身份可能持有
+- **解离性遗忘（DA）**：多为对创伤事件/特定时间段的广泛失忆，可横跨身份；见[解离性遗忘](Dissociative-Amnesia-DA.md)。
+- **状态依赖性记忆（SDM）**：在特定生理/情绪/身份状态下更易提取；非病理概念，可在健康人中出现。
+- **记忆屏蔽**：系统内针对性限制访问；可由 SDM 与防御性分隔共同呈现。
 
 ### 与独有记忆（Exomemory）的区别
 
 - **独有记忆**：某个身份独立经历的事件，其他身份未参与因而无法回忆[见[独有记忆（Exomemory）](Exomemory.md)]
 - **记忆屏蔽**：共同经历或可共享的记忆被主动或被动地限制访问
 
-### 与记忆缺失的其他原因
+### 与记忆缺失的其他原因（鉴别要点）
 
-需排除以下可能：
+- 物质/药物所致遗忘：酒精、苯二氮䓬类、镇静催眠药与麻醉后遗忘；与剂量/时间相关。
+- 神经系统疾病：癫痫（尤其颞叶）、TBI/脑炎/中风等；需神经科评估与客观检查。
+- 精神病性障碍：妄想/幻觉主导的叙事不连续与创伤分隔不同；注意现实检验能力与思维形式障碍。
+- 睡眠相关：梦游/快速眼动期行为障碍/睡眠剥夺导致的记忆片段化。
+- 一般遗忘/编码不足：注意力与负荷因素，非身份依赖性差异。
 
-- 药物或酒精影响导致的记忆空白
-- 脑损伤或神经系统疾病引起的记忆障碍
-- 注意力不集中或未充分编码导致的记忆缺失
-- 睡眠障碍相关的记忆问题
+> 小贴士：若怀疑医学或物质因素，请先行转诊/联合评估，以免将器质性问题误归因于解离。
+
+## 与相关概念对照（对照表）
+
+| 概念 | 定义要点 | 官方地位 | 典型表现 | 备注/链接 |
+|------|----------|----------|----------|-----------|
+| 记忆屏蔽 | 身份间对特定记忆的访问限制（主动/被动） | 社群/经验性术语（非 DSM/ICD） | 选择性遗忘、触发下片段泄漏 | 本页术语 |
+| 解离性遗忘（DA） | 创伤事件/时段的广泛失忆 | DSM-5-TR/ICD-11 诊断范畴 | 重要自传信息缺失 | [Dissociative-Amnesia-DA.md](Dissociative-Amnesia-DA.md) |
+| 状态依赖性记忆（SDM） | 编码—提取依赖相似状态 | 一般心理学概念 | 状态改变则难以回忆 | 非病理，可与解离并存 |
+| 独有记忆（Exomemory） | 特定身份独立经历之记忆 | 社群术语 | 他人未参与因而不知晓 | [Exomemory.md](Exomemory.md) |
+| 压制/压抑 | 有意压下/无意识排斥念头 | 心理学术语 | 回避或缺乏自觉 | 概念上与“屏蔽”不同 |
 
 ## 干预
 
-### 治疗原则
+本节强调“促进加工与整合”，而非直接“解除屏蔽”。遵循阶段化与循证框架，优先保障安全与功能。
 
-在专业治疗情境下处理记忆屏蔽时，应遵循以下原则：
+### 阶段化路径（建议遵循）
 
-1. **安全第一**：确保个体在情绪和心理上有足够的稳定性来处理被屏蔽的记忆
-2. **渐进原则**：避免过快拆除屏蔽，可能导致再创伤或系统崩溃
-3. **系统共识**：尽可能获得系统内部多数成员的同意和配合
-4. **功能导向**：评估记忆屏蔽是否影响日常功能，并非所有屏蔽都需要立即解除[^isdtd2011]
+- 第 1 阶段：稳定化与安全——接地、情绪调节、危机计划、身份间沟通规范（见[三阶段创伤治疗模型](Three-Phase-Trauma-Treatment.md)；[阶段化原则](Phase-Oriented-Treatment-Principles.md)；参见 ISSTD 指南[^isstd2011]）。
+- 第 2 阶段：创伤加工——在稳定化前提下，逐步暴露与加工相关材料，控制强度与节奏。
+- 第 3 阶段：整合与重建——巩固功能、协调身份间共享与边界，避免强迫“拆墙”。
 
-### 专业治疗方法
+### 循证路径（在稳定化前提下开展）
 
-**1. 渐进式暴露（Graduated Exposure）**
+- 眼动脱敏与再加工（[EMDR](Eye-Movement-Desensitization-Reprocessing-EMDR.md)）：用于创伤记忆的再加工与情绪再评估，目标是促进适应性整合，而非“解锁记忆”[^shapiro2017]。
+- 认知处理治疗（[CPT](Cognitive-Processing-Therapy-CPT.md)）：修正与创伤相关的适应不良信念，支持意义重建与系统协作。
+- 延长暴露（[PE](Prolonged-Exposure-Therapy-PE.md)/渐进式暴露）：在可承受窗口内、以小步推进的方式面对触发线索，配合[接地（Grounding）](Grounding.md)。
+- 内部沟通强化：建立安全的身份间通道（会议/日志/中立托管者；见[内部沟通](Internal-Communication.md)），尊重边界与不同成员的“知情权”。
 
-- 在安全环境下，逐步接近被屏蔽的记忆内容
-- 从低强度、非核心细节开始，逐渐深入
-- 结合稳定化技术和接地技巧（Grounding）
-
-**2. 眼动脱敏与再加工（EMDR）**
-
-- 针对创伤记忆的循证治疗方法
-- 帮助重新加工被屏蔽的创伤记忆，降低其情绪强度
-- 促进记忆的适应性整合[^shapiro2017]
-
-**3. 内部沟通强化**
-
-- 建立系统成员之间的安全沟通渠道
-- 通过日记、内部会议等方式促进信息共享
-- 尊重个别成员的边界，避免强制访问
-
-**4. 认知处理治疗（CPT）**
-
-- 处理与创伤记忆相关的适应不良信念
-- 帮助系统重新评估被屏蔽记忆的意义
-- 促进记忆的认知整合
+> 证据限定语：关于多意识体人群的疗效数据相对有限、样本量较小且异质；应个案化评估、动态调整。
 
 ### 自我管理策略
 
@@ -167,7 +172,7 @@ comments: true
 
 **3. 接地与稳定化**
 
-- 在探索被屏蔽记忆前，确保有效的接地技巧[见[接地技巧（Grounding）](Grounding.md)]
+- 在探索被屏蔽记忆前，先确保有效的接地技巧（见[接地技巧（Grounding）](Grounding.md)）
 - 建立安全信号和紧急停止机制
 - 维持日常生活的稳定性和可预测性
 
@@ -175,10 +180,15 @@ comments: true
 
 !!! warning "重要警告"
 
-    - **过度屏蔽风险**：可能导致系统沟通断裂、功能下降或日常生活受损
-    - **快速解除风险**：突然拆除屏蔽可能引发闪回、解离发作或情绪崩溃
-    - **创伤记忆处理**：涉及严重创伤的记忆屏蔽应在专业治疗师指导下处理
-    - **功能性屏蔽**：某些屏蔽可能在当前阶段具有保护作用，不应强制解除
+    - 过度屏蔽：可能导致沟通断裂、功能下降或生活连续性受损。
+    - 快速拆除：骤然“拆墙”易致闪回、解离发作或情绪崩溃。
+    - 创伤加工：严重创伤材料务必在专业者督导下推进，并允许随时暂停/回滚。
+    - 功能优先：屏蔽在某阶段可能具有保护价值，不必强求解除。
+
+!!! danger "法证与记忆可靠性（边界警示）"
+    - 禁用诱导性技术：避免引导性提问、暗示性想象、非适应性催眠与“恢复记忆”做法，防假性记忆与污染。
+    - 法证场景慎用回忆技术：保持中立与不可暗示，必要时转介具资质的法证评估；全过程记录并避免信息交叉污染。
+    - 教育与知情：解释创伤记忆常见的碎片化/闯入，并非“必然存在被屏蔽的完整记忆”。
 
 ## 相关条目
 
@@ -191,14 +201,15 @@ comments: true
 - [碎片（Fragment）](Fragment.md) - 可能持有碎片化记忆的身份类型
 - [融合（Fusion）](Fusion.md) - 可能涉及记忆整合的过程
 - [解离障碍（Dissociative Disorders）](Dissociative-Disorders.md) - 记忆屏蔽常见的临床背景
+- [解离性身份障碍（DID）](DID.md) / [其他特定解离障碍（OSDD）](OSDD.md) - 与身份相关的记忆差异
 
 ## 参考与延伸阅读
 
-[^dsm5]: American Psychiatric Association. (2013). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed.). American Psychiatric Publishing.
-[^schlumpf2014]: Schlumpf, Y. R., et al. (2014). Dissociative Part-Dependent Resting-State Activity in Dissociative Identity Disorder: A Controlled fMRI Perfusion Study. *PLoS ONE*, 9(6), e98795.
-[^frey2019]: Frey, L. M., & Cloitre, M. (2019). Protective Dissociation: Memory Compartmentalization in Survivors of Complex Trauma. *European Journal of Psychotraumatology*, 10(1), 1601995.
-[^isdtd2011]: International Society for the Study of Trauma and Dissociation. (2011). Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision. *Journal of Trauma & Dissociation*, 12(2), 115–187.
-[^shapiro2017]: Shapiro, F. (2017). *Eye Movement Desensitization and Reprocessing (EMDR) Therapy: Basic Principles, Protocols, and Procedures* (3rd ed.). Guilford Press.
+[^dsm5tr]: American Psychiatric Association. (2022). Diagnostic and Statistical Manual of Mental Disorders (5th ed., Text Revision). American Psychiatric Publishing.
+[^schlumpf2014]: Schlumpf, Y. R., et al. (2014). Dissociative Part-Dependent Resting-State Activity in Dissociative Identity Disorder: A Controlled fMRI Perfusion Study. PLoS ONE, 9(6), e98795.
+[^frey2019]: Frey, L. M., & Cloitre, M. (2019). Protective Dissociation: Memory Compartmentalization in Survivors of Complex Trauma. European Journal of Psychotraumatology, 10(1), 1601995.
+[^shapiro2017]: Shapiro, F. (2017). Eye Movement Desensitization and Reprocessing (EMDR) Therapy: Basic Principles, Protocols, and Procedures (3rd ed.). Guilford Press.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision. Journal of Trauma & Dissociation, 12(2), 115–187.
 
 **延伸资源**：
 


### PR DESCRIPTION
### 变更动机
- 将“记忆屏蔽（Memory Shielding）”明确标注为社群/经验性术语，避免在临床/法证文本中被误作诊断名词；
- 对齐全站的诊断与编码映射口径，区分 DA 与状态依赖性记忆（SDM），降低歧义与滥用风险；
- 强化法证与记忆可靠性边界，避免诱导性技术与不当“恢复记忆”。

### 主要改动点
- 首屏新增 Clinician’s Summary（150–200字），强调“稳定化→加工/整合”路径；
- 术语状态块：标注为“非 DSM-5-TR / ICD-11 正式术语”；
- 统一诊断与编码映射：DSM‑5‑TR DID 300.14（F44.81）、ICD‑11 DID 6B64；
- 新增“与相关概念对照（对照表）”：记忆屏蔽 / DA / SDM / Exomemory / 压制；
- 干预段落改写：EMDR/CPT/PE 作为促进加工与整合的循证路径（需稳定化前提），避免“解除屏蔽”的表述；
- 新增“法证与记忆可靠性”危险提示块；
- 首处链接：DID、OSDD、Grounding、Three‑Phase、Phase‑Oriented、EMDR、CPT、PE 等；
- Frontmatter 优化：description（≤160字）、search.boost: 1.4、synonyms 扩充；
- 参考文献统一：DSM‑5 改为 APA, 2022 DSM‑5‑TR；补充 Shapiro (2017), ISSTD (2011)；对神经影像与疗效表述增加“样本量小/异质/不一致”的限定语。

### 潜在风险
- 词条语气更为保守，可能降低“机制确定性”的读感，但与当前证据强度匹配；
- 对术语边界的强调，可能与部分社群习惯用法不一致（已在文本中保留社群语境）。

### 关联条目/文档
- docs/entries/Memory-Shielding.md（本次修订）
- 已存在引用：System-Operations-Guide.md（无需变更）

### 验证
- 链接检查：python3 tools/check_links.py docs/entries/Memory-Shielding.md → 通过

### 变更范围与方法来源
- 手工修订 + 规范性检查；无批量脚本/正则重写。
