### PR TITLE
fix(pdf-export): 修复前言文档处理和增加 admonitions 转换支持

### DIFF
--- a/tools/pdf_export/pdf_export/cli.py
+++ b/tools/pdf_export/pdf_export/cli.py
@@ -155,12 +155,14 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     if sys.stdout.isatty():
         print("📚 收集 Markdown 文件结构...")
-    structure = collect_markdown_structure(ignore_rules)
+    preface_doc, structure = collect_markdown_structure(ignore_rules)
     if not structure:
         raise SystemExit("没有找到可以导出的 Markdown 文件。")
 
     # 统计文件数量
     total_entries = sum(len(entries) for _, entries in structure)
+    if preface_doc:
+        total_entries += 1  # 包含前言
     if sys.stdout.isatty():
         print(f"   找到 {len(structure)} 个分类，共 {total_entries} 个文档")
 
@@ -179,6 +181,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     if sys.stdout.isatty():
         print("🔨 合并 Markdown 内容...")
     combined_markdown = build_combined_markdown(
+        preface_doc=preface_doc,
         structure=structure,
         include_readme=args.include_readme or not ignore_rules.matches(README_PATH),
         include_cover=not args.no_cover,


### PR DESCRIPTION
## 摘要

本 PR 修复了 PDF 导出工具中前言文档的处理问题,并新增了对 MkDocs Material admonitions 语法的转换支持。

## 主要更改

### 1. 前言文档处理优化
- **问题**: 前言文档之前作为普通章节处理,且 frontmatter 会显示在 PDF 中
- **解决方案**:
  - 将前言从章节结构中独立出来,放置在封面和目录之后
  - 添加 frontmatter 过滤逻辑,移除 YAML 元数据
  - 修正文档顺序: 封面 → 目录 → 前言 → README → 内容章节

### 2. Admonitions 转换支持
- **功能**: 将 MkDocs Material 的 `!!! type "title"` 语法转换为 LaTeX 兼容的块引用
- **支持类型**: 
  - note (备注📝), info (信息ℹ️), tip (提示💡)
  - warning (警告⚠️), danger (危险🚫)
  - success (成功✅), failure (失败❌), bug (错误🐛)
  - example (示例📋), question (问题❓)
  - quote (引用💬), abstract (摘要📄)
- **转换格式**:
  ```markdown
  !!! warning "注意事项"
      这是警告内容
  ```
  转换为:
  ```markdown
  > **⚠️ 警告: 注意事项**
  >
  > 这是警告内容
  ```

### 3. 文件统计修正
- 在统计文件数量时正确包含前言文档
- 确保控制台输出的文件数量准确

## 技术实现

### 新增函数
- `convert_admonitions_to_latex()`: 处理 admonitions 语法转换
- `_load_preface_document()`: 独立加载前言文档(含 frontmatter 过滤)

### 修改函数
- `collect_markdown_structure()`: 返回值改为 `(preface_doc, structure)` 元组
- `build_combined_markdown()`: 接受 `preface_doc` 参数并在正确位置插入

## 测试验证

- [x] 前言文档正确插入且无 frontmatter 泄露
- [x] Admonitions 转换为可读的块引用格式
- [x] 文件统计数量准确
- [x] PDF 生成流程无报错
- [x] 章节顺序符合预期

## 影响范围

- 仅影响 PDF 导出功能
- 不影响 MkDocs 网站构建
- 向后兼容现有文档

## 相关文件

- [tools/pdf_export/pdf_export/cli.py](tools/pdf_export/pdf_export/cli.py)
- [tools/pdf_export/pdf_export/structure.py](tools/pdf_export/pdf_export/structure.py)
- [tools/pdf_export/pdf_export/markdown.py](tools/pdf_export/pdf_export/markdown.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)