### PR TITLE
docs: 补充迫害者角色概述

### DIFF
--- a/docs/entries/Roles-Identity-Guide.md
+++ b/docs/entries/Roles-Identity-Guide.md
@@ -55,7 +55,7 @@ updated: 2025-10-20
 
 - 🔒 [守门人（Gatekeeper）](Gatekeeper.md)：控制切换与访问权限。
 - 🛡️ [保护者（Protector）](Protector.md)：防御外部威胁与内部危机。
-- ⚠️ [迫害者（Persecutor）](Persecutor.md)：
+- ⚠️ [迫害者（Persecutor）](Persecutor.md)：通过敌对或自惩行为阻止系统再次受创。
 
   !!! warning "防误用"
       源自防御机制的自我保护角色，**非攻击他人或“坏人格”**。


### PR DESCRIPTION
## Summary
- 为《系统角色指南》中的迫害者条目补充核心职能概述，强调其防御性目的
- 保留既有防误用提示，引导读者以创伤知情视角理解迫害者角色

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f826f438ec8333b0e82619037e003a