### PR TITLE
refactor: 重构 SSD 词条，结构对齐 DID 标杆

### DIFF
--- a/docs/entries/Somatic-Symptom-Disorder-SSD.md
+++ b/docs/entries/Somatic-Symptom-Disorder-SSD.md
@@ -1,78 +1,140 @@
 ---
 comments: true
+description: 围绕一个或多个持续性躯体症状所引发的显著痛苦与功能受损,并伴对症状的过度思考、情绪与行为反应。DSM-5-TR 强调心理行为影响,即使合并真实躯体病也可诊断;ICD-11 对应为躯体痛苦障碍(BDD)。
+synonyms:
+
+  - 躯体症状障碍
+  - Somatic Symptom Disorder
+  - 躯体化障碍（历史用语）
+  - 躯体形式障碍（历史范畴）
+
 tags:
 
-- guide:诊断与临床
-- dx:解离障碍
+  - guide:诊断与临床
+  - dx:躯体症状障碍（SSD）
+  - dx:躯体症状及相关障碍
 
-title: 躯体化障碍（Somatic Symptom Disorder，SSD）
+title: 躯体症状障碍（Somatic Symptom Disorder，SSD）
 topic: 诊断与临床
 updated: 2025-10-20
 ---
 
-# 躯体化障碍（Somatic Symptom Disorder，SSD）
+# 躯体症状障碍（Somatic Symptom Disorder，SSD）
 
 !!! warning "触发警告"
-    内容涉及创伤、精神健康、自我认同等敏感议题,阅读时请留意自身状态。
+    内容涉及身心症状、精神健康等敏感议题,阅读时请留意自身状态。
 
 !!! info "免责声明"
     本站资料仅供参考,不构成医疗建议。若需诊断或治疗,请联系持证专业人员。
 
-## 同义词
+---
 
-- 躯体症状障碍（Somatic Symptom Disorder, SSD）
-- 躯体化障碍（Somatization Disorder，历史用语）
-- 躯体形式障碍（历史诊断范畴）
+## 概述
 
-## 定义
+> 核心要点速览：SSD 的核心是对一个或多个躯体症状的持续困扰与过度的认知‑情绪‑行为反应,强调“症状带来的影响”,而非“是否有医学解释”。即便存在可解释的躯体疾病,只要伴随不相称的担忧与持续功能受损,亦可满足诊断。
 
-躯体化障碍指个体经历一个或多个持续存在的躯体症状，并伴随与这些症状相关的显著痛苦、功能损害及过度的思想、情感或行为反应。与以往强调“无医学依据”的躯体化概念不同，DSM-5-TR 的诊断更关注症状带来的心理行为影响，即使存在可解释的躯体疾病，也可能同时符合此诊断。
+SSD 隶属于“躯体症状及相关障碍”谱系（参见[诊断与临床导览](Clinical-Diagnosis-Guide.md)相关章节）。与历史术语“躯体化障碍/躯体形式障碍”不同,DSM‑5‑TR 取消了“无医学依据”作为必要条件,改强调症状引发的心理行为后果。ICD‑11 在对应位置使用“躯体痛苦障碍（Bodily Distress Disorder, BDD）”,二者在具体阈值与说明符上存在差异,但核心思路一致。
 
-## DSM-5-TR 诊断要点
+!!! info "Clinician’s Summary｜快速临床要点"
+    - 诊断核心：1) 一个或多个困扰性躯体症状; 2) 对症状的过度想法/焦虑/行为之一或多项; 3) 症状状态持续性（通常 ≥6 月）。排除急危重躯体病与谵妄,注意药物/物质影响。
+    - 评估路径：病史+体检+必要的聚焦检查 → 量表化筛查（PHQ‑15、SSD‑12、[SDQ‑20](Somatoform-Dissociation-Questionnaire-SDQ-20.md)）→ 识别健康焦虑/灾难化思维 → 纵向随访功能受损程度。
+    - 治疗原则：建立稳定医患联盟与定期随访; 心理教育+CBT/ACT/正念; 合并焦抑可酌用抗抑郁药; 避免重复无效检查与过度医疗; 与多学科协作（身心整合）。
 
-DSM-5-TR 将躯体症状障碍归入“躯体症状及相关障碍”章节。诊断需满足以下特征：
+---
 
-1. **一个或多个困扰性的躯体症状** ，并造成日常生活的显著扰乱。
-2. **与躯体症状相关的过度思想、情感或行为** ，至少具备以下之一：
+## 诊断要点
 
-    - 对症状严重性的持续且不成比例的想法；
-    - 持续的高水平焦虑或关注；
-    - 花费过多时间和精力在症状或健康忧虑上。
-3. 尽管单个躯体症状可能并非持续存在，但症状状态通常是持续性的（一般超过 6 个月）。
+### DSM‑5‑TR（躯体症状障碍, SSD）
 
-DSM-5-TR 允许按照症状持续时间（急性 < 6 个月；慢性 ≥ 6 个月）及是否伴有以疼痛为主的表现等进行说明。
+- 一个或多个困扰性的躯体症状,造成日常显著扰乱。
+- 与躯体症状相关的过度思想/情感/行为（至少其一）：
+  - 对严重性的持续且不成比例的想法;
+  - 持续的高水平焦虑或关注;
+  - 在症状或健康忧虑上投入过多时间与精力。
+- 症状状态通常持续（一般 ≥ 6 个月）。
+- 说明符：以疼痛为主; 急性/慢性; 伴严重度分级。
 
-## ICD-11 诊断特征
+**来源**：American Psychiatric Association. (2022). DSM‑5‑TR.
 
-在 ICD-11 中，对应的诊断为 **躯体痛苦障碍（Bodily Distress Disorder）** 。其核心表现为持续困扰性的躯体症状，以及对这些症状过度的关注和重复的医疗寻求行为。ICD-11 强调症状体验与心理行为反应之间的恶性循环，并允许按主要症状领域（如心血管、胃肠道、疼痛或混合型）进行说明。
+### ICD‑11（躯体痛苦障碍, BDD）
 
-## 评估与鉴别
+- 持续存在的躯体症状,伴对这些症状的过度关注、反复医疗寻求与显著功能受损。
+- 强调身心相互放大与“症状‑担忧‑回避/就医”的恶性循环。
+- 可按主要症状领域（如疼痛、心血管、胃肠、混合型）添加说明。
 
-- 评估时需结合详细的病史、体格检查和必要的医学评估，排除急性、危及生命的躯体疾病。
-- 鉴别诊断包括疾病焦虑障碍、[功能性神经症状障碍（Conversion Disorder/FND）](Conversion-Disorder-FND.md)、躯体症状伴抑郁或焦虑障碍以及物质/药物所致症状等。
-- 共病常见于焦虑障碍、抑郁障碍、创伤相关障碍与人格特质问题，系统化评估可帮助制定治疗方案。
+**来源**：World Health Organization. ICD‑11 MMS（2019/2022 浏览版本）。
+
+### DSM 与 ICD 差异简述
+
+- DSM‑5‑TR 强调“症状引发的心理行为反应”的阈值与持续性; ICD‑11 BDD 更聚焦“躯体痛苦综合”与维持机制,并提供症状领域说明符。
+- 临床使用时需注意用语差异,但二者均反对以“无医学依据”作为必要前提。
+
+---
+
+## 临床表现
+
+- 躯体症状群：常见为慢性疼痛（头/颈/背/四肢）、胃肠不适（恶心、腹痛、腹胀）、心血管主诉（心悸、胸闷）、神经感觉异常（麻木、眩晕、主观虚弱）。
+- 认知与情绪：灾难化解读、选择性注意健康线索、持续不安与恐惧、对检查结果的暂时性安慰但很快复燃的担忧。
+- 行为模式：高频就医与科室流转、重复检查、过度自我监测/查资料、回避活动（担心“伤害身体”）。
+- 功能影响：社交/工作/学习受损; 活动减少导致体能下降,进一步放大症状体验。
+
+---
+
+## 评估与量表
+
+- 医学评估：详尽病史与体检,聚焦性检查用于排除急危重或可逆病因; 避免无目标的过度检查。
+- 心理评估：
+  - PHQ‑15（躯体症状严重度）
+  - SSD‑12（认知‑情绪‑行为反应）
+  - [SDQ‑20（躯体形式解离问卷）](Somatoform-Dissociation-Questionnaire-SDQ-20.md): 识别躯体解离特征（感觉异常/运动障碍等）
+  - Whiteley Index（健康焦虑）
+
+---
+
+## 鉴别诊断
+
+- [疾病焦虑障碍（Illness Anxiety Disorder, IAD）](Illness-Anxiety-Disorder.md)：以健康忧虑为主、躯体症状轻微或缺如；SSD 则有显著躯体症状。
+- [功能性神经症状障碍/转换障碍（FND）](Conversion-Disorder-FND.md)：神经功能症状（运动/感觉/发作样）为主，体征‑症状不一致; 两者可共存。
+- [抑郁/焦虑障碍](Depressive-Disorders.md)：可伴广泛躯体不适; 当过度反应围绕特定症状群且长期功能受损时考虑 SSD。
+- 影响其他躯体疾病的心理因素（PFAOMC）：已有明确躯体病,心理因素影响病程/依从性/预后。
+- 做作性障碍与诈病：有意制造/伪装症状（动机不同）；SSD 中不存在有意欺骗。
+
+---
+
+## 共病与风险管理
+
+- 常见共病：焦虑障碍、抑郁障碍、[创伤及应激相关障碍](PTSD.md); 部分个体伴[躯体形式解离](Somatoform-Dissociation-Questionnaire-SDQ-20.md)特征。
+- 医疗使用风险：重复就医与过度检查/治疗（包括滥用止痛药、镇静药）→ 医源性伤害风险上升。
+- 管理要点：
+  - 设定固定随访与单一协调医师,减少多头就诊带来的信息碎片化;
+  - 明确“红旗征”快速就医清单,其他情况优先在随访中处理;
+  - 与家属/照护者进行身心同构的心理教育,降低焦虑驱动的回避与检查需求。
+
+---
 
 ## 治疗与支持
 
-- **心理教育与医患联盟** : 解释身心交互机制、设定现实期望，建立稳定的随访关系。
-- **心理治疗** : 认知行为治疗（CBT）、正念干预、应对技能训练等有助于调整不良认知与行为。
-- **药物治疗** : 若合并抑郁或焦虑症状，可考虑抗抑郁药物；应避免过度使用止痛药或镇静药。
-- **综合照护** : 鼓励规律生活、运动与社会支持，必要时与躯体科、康复、精神卫生团队协作。
+- 心理教育与联盟：解释身心交互与维持机制,对齐可实现目标（功能提升 vs. 症状清零）。
+- 心理治疗：以 **CBT**（认知重评、暴露与反应预防、活动安排）、**ACT**、**正念** 为主; 结合行为激活改善活动水平。
+- 药物治疗：针对合并的抑郁/焦虑等（如 SSRIs/SNRIs）; 避免不必要的镇痛/镇静药长期化。
+- 综合照护：身心整合随访（全科/身心科/康复/心理治疗）; 鼓励规律作息、运动与社会支持。
+
+---
 
 ## 相关条目
 
-- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
-- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](Narcissistic-Personality-Disorder-NPD.md)
-- [精神分裂症（Schizophrenia，SZ/SCZ）](Schizophrenia-SZ.md)
-- [焦虑障碍（Anxiety Disorders）](Anxiety-Disorders.md)
-- [边缘性人格障碍（Borderline Personality Disorder，BPD）](Borderline-Personality-Disorder-BPD.md)
-- [抑郁障碍（Depressive Disorders）](Depressive-Disorders.md)
-- [心境障碍（Affective Disorders）](Affective-Disorders.md)
-- [情感障碍（Mood Disorders）](Mood-Disorders.md)
-- [功能性神经症状障碍（Functional Neurological Symptom Disorder，FND）](Conversion-Disorder-FND.md)
+- [诊断与临床导览](Clinical-Diagnosis-Guide.md)
+- [功能性神经症状障碍/转换障碍（FND）](Conversion-Disorder-FND.md)
+- [慢性疼痛（Chronic Pain）](Chronic-Pain.md)
+- [疾病焦虑障碍（IAD）](Illness-Anxiety-Disorder.md)
+- [抑郁障碍](Depressive-Disorders.md) · [焦虑障碍](Anxiety-Disorders.md)
+- [躯体形式解离问卷（SDQ‑20）](Somatoform-Dissociation-Questionnaire-SDQ-20.md)
 
-## 参考资料
+---
 
-1. American Psychiatric Association. _Diagnostic and Statistical Manual of Mental Disorders_ (5th ed., Text Revision), 2022.
-2. World Health Organization. _International Classification of Diseases 11th Revision_, 2022.
-3. "Somatic symptom disorder" — Wikipedia, the free encyclopedia. Accessed 2024.
+## 参考与延伸阅读
+
+1. American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders (5th ed., text rev.)*.
+2. World Health Organization. (2019/2022). *ICD‑11 for Mortality and Morbidity Statistics*.
+3. Creed, F., & Barsky, A. (2004). A systematic review of the epidemiology of somatisation disorder. *J Psychosom Res*.
+4. Häuser, W., et al. (2017). Functional somatic syndromes and somatoform disorders. *Dtsch Arztebl Int*.


### PR DESCRIPTION
本 PR 聚焦重构 docs/entries/Somatic-Symptom-Disorder-SSD.md，使其结构与 DID 词条标杆对齐，并修正标签与链接。

变更
- 结构：按 概述 → 诊断要点（DSM-5-TR / ICD-11 + 差异）→ 临床表现 → 评估与量表（PHQ‑15/SSD‑12/SDQ‑20/Whiteley）→ 鉴别诊断 → 共病与风险管理 → 治疗与支持 → 相关条目 → 参考文献 重排与补全
- Frontmatter：新增 description / synonyms，修正 tags 为 、、
- 链接：移除不存在的词条链接，统一为站内已有条目与导览页；路径均为相对路径

规范遵循
- 语言与路径：中文内容；词条间直接文件名；未使用绝对路径
- Frontmatter：未手动修改 updated（CI 维护）；必需字段完整
- 标签规范：通过（单文件验证）
- 链接规范：通过（单文件验证）

本地检查（仅针对改动文件）
======================================================================
Markdown 链接规范检查
======================================================================
仓库根目录：/home/lianlian/project/Multiple_personality_system_wiki
扫描路径：/home/lianlian/project/Multiple_personality_system_wiki/docs/entries/Somatic-Symptom-Disorder-SSD.md

找到 1 个 Markdown 文件

======================================================================
[OK] 所有链接均符合规范
✅ 标签规范检查通过

影响范围
- 仅文档内容更新，不涉及脚本/配置；对应导览页  已有 SSD 链接，无需同步更新

请审阅，如需我补充 ICD‑11 躯体痛苦障碍（BDD）独立词条，可在本 PR 中提出。
