### PR TITLE
feat: 为 PDF 导出工具添加精简版功能

### DIFF
--- a/tools/pdf_export/LITE_VERSION_GUIDE.md
+++ b/tools/pdf_export/LITE_VERSION_GUIDE.md
@@ -1,0 +1,177 @@
+# 精简版 PDF 生成指南
+
+本指南说明如何生成只包含部分词条的精简版 PDF。
+
+## 快速开始
+
+### 方式 1: 按标签筛选（最简单）
+
+只需指定要包含或排除的标签即可:
+
+```bash
+# 只导出解离障碍相关词条（约 126 个）
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "dx:解离障碍" \
+  --output MPS_Wiki_Dissociation.pdf
+
+# 只导出系统运作相关词条（约 54 个）
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "ops:系统运作" \
+  --output MPS_Wiki_Operations.pdf
+
+# 导出除了共病和风险管理之外的所有词条
+python tools/pdf_export/export_to_pdf.py \
+  --exclude-tags "dx:共病,guide:风险管理" \
+  --output MPS_Wiki_Core.pdf
+```
+
+### 方式 2: 使用白名单（精确控制）
+
+1. 创建一个文本文件，列出要导出的词条:
+
+```bash
+cat > my-lite-entries.txt << 'EOF'
+# 我的精选词条
+Alter.md
+DID.md
+OSDD.md
+Switch.md
+Front-Fronting.md
+Trauma.md
+Grounding.md
+EOF
+```
+
+2. 使用白名单导出:
+
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --entry-list my-lite-entries.txt \
+  --output MPS_Wiki_My_Selection.pdf
+```
+
+### 方式 3: 组合使用
+
+可以同时使用白名单和标签过滤:
+
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --entry-list my-lite-entries.txt \
+  --exclude-tags "guide:风险管理" \
+  --output MPS_Wiki_Custom.pdf
+```
+
+## 常用标签参考
+
+根据词条数量排序的常用标签（截至 2025-10）:
+
+| 标签 | 词条数 | 说明 |
+|------|--------|------|
+| `dx:解离障碍` | 129 | 解离障碍相关诊断 |
+| `guide:诊断与临床` | 110 | 临床诊断指南 |
+| `sx:创伤症状` | 100 | 创伤相关症状 |
+| `ops:系统运作` | 54 | 系统日常运作 |
+| `role:系统角色` | 37 | 系统成员角色 |
+| `tx:创伤治疗` | 18 | 创伤治疗方法 |
+| `guide:风险管理` | 16 | 风险管理指南 |
+| `dx:共病` | 16 | 共病诊断 |
+| `culture:文化表现` | 16 | 文化与媒体表现 |
+| `community:Tulpa` | 13 | Tulpa 社区 |
+| `guide:实践指南` | 12 | 实践操作指南 |
+| `dx:焦虑障碍` | 10 | 焦虑障碍诊断 |
+| `tx:心理治疗` | 10 | 心理治疗方法 |
+| `guide:创造型系统` | 10 | 创造型系统指南 |
+
+## 推荐配置
+
+### 新手入门版（推荐给初次了解的读者）
+
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "ops:系统运作,role:系统角色" \
+  --output MPS_Wiki_Beginner.pdf
+```
+
+预计词条数: 约 70-90 个
+
+### 临床专业版（适合心理健康专业人士）
+
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "guide:诊断与临床,tx:创伤治疗,dx:解离障碍" \
+  --output MPS_Wiki_Clinical.pdf
+```
+
+预计词条数: 约 150-200 个
+
+### Tulpa 专题版
+
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "community:Tulpa,guide:创造型系统" \
+  --output MPS_Wiki_Tulpa.pdf
+```
+
+预计词条数: 约 20-25 个
+
+## 白名单文件格式
+
+白名单文件是纯文本文件，每行一个词条:
+
+```text
+# 注释行以 # 开头
+# 可以使用文件名（推荐）
+Alter.md
+DID.md
+
+# 也可以使用词条标题
+成员（Alter）
+解离性身份障碍（Dissociative Identity Disorder，DID）
+
+# 空行会被忽略
+```
+
+## 查看可用标签
+
+要查看所有可用标签及其词条数，可以运行:
+
+```bash
+python3 -c "
+import yaml
+from pathlib import Path
+from collections import Counter
+
+tags_counter = Counter()
+for md_file in Path('docs/entries').glob('*.md'):
+    content = md_file.read_text(encoding='utf-8')
+    if content.startswith('---'):
+        lines = content.split('\n')
+        end_idx = lines[1:].index('---') + 1
+        frontmatter = '\n'.join(lines[1:end_idx])
+        try:
+            data = yaml.safe_load(frontmatter)
+            if 'tags' in data and isinstance(data['tags'], list):
+                for tag in data['tags']:
+                    tags_counter[tag] += 1
+        except: pass
+
+for tag, count in tags_counter.most_common():
+    print(f'{tag}: {count}')
+"
+```
+
+## 提示
+
+1. **组合标签**: 多个标签用逗号分隔，词条只要包含任一标签即会被选中
+2. **排除优先**: 如果同时使用 `--include-tags` 和 `--exclude-tags`，排除规则优先级更高
+3. **白名单精确**: 使用白名单可以精确控制导出哪些词条
+4. **自定义输出**: 使用 `-o` 或 `--output` 指定输出文件名
+5. **帮助信息**: 运行 `python tools/pdf_export/export_to_pdf.py --help` 查看所有参数
+
+## 示例文件
+
+项目提供了一个示例白名单文件:
+
+- [example-lite-entries.txt](example-lite-entries.txt) - 精选的核心词条列表
+
+你可以基于此文件修改创建自己的白名单。

--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -70,3 +70,111 @@ python tools/pdf_export/export_to_pdf.py --pdf-engine xelatex
 - 目录页会基于 topic 结构生成“图书式”目录，并为每个词条显示页码。
 
 如需进一步自定义输出文件名或其他设置，可执行 `python tools/pdf_export/export_to_pdf.py --help` 查看全部参数。
+
+## 精简版 PDF 导出
+
+如果完整版 PDF 太大，可以使用以下方式创建精简版，只导出部分词条：
+
+### 方式 1：按标签筛选
+
+使用 `--include-tags` 参数只导出包含特定标签的词条：
+
+```bash
+# 只导出基础概念和入门指南类词条
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "基础概念,入门指南" \
+  --output MPS_Wiki_Lite.pdf
+
+# 只导出临床诊断相关词条
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "临床诊断,治疗方法" \
+  --output MPS_Wiki_Clinical.pdf
+```
+
+使用 `--exclude-tags` 参数排除特定标签的词条：
+
+```bash
+# 排除进阶内容和实验性内容
+python tools/pdf_export/export_to_pdf.py \
+  --exclude-tags "进阶内容,实验性" \
+  --output MPS_Wiki_Basic.pdf
+```
+
+标签过滤规则：
+
+- `--include-tags`: 词条至少包含一个指定标签即会被导出
+- `--exclude-tags`: 词条包含任一排除标签即会被过滤掉
+- 可同时使用两个参数，先应用 include 再应用 exclude
+- 多个标签用逗号分隔
+
+### 方式 2：使用词条白名单
+
+创建一个文本文件，每行写一个要导出的词条（可以是文件名或标题）：
+
+```bash
+# 创建白名单文件 lite-entries.txt
+cat > lite-entries.txt << 'EOF'
+# 核心概念
+Alter.md
+DID.md
+OSDD.md
+Multiple-System.md
+
+# 基础操作
+Switching.md
+Fronting.md
+Co-Fronting.md
+
+# 也可以使用词条标题
+人格（Alter）
+解离性身份障碍（DID）
+EOF
+
+# 使用白名单导出
+python tools/pdf_export/export_to_pdf.py \
+  --entry-list lite-entries.txt \
+  --output MPS_Wiki_Core.pdf
+```
+
+白名单文件格式：
+
+- 每行一个词条，可以是文件名（如 `Alter.md`）或词条标题（如 `人格（Alter）`）
+- 支持 `#` 开头的注释行
+- 空行会被忽略
+
+### 方式 3：组合使用
+
+可以组合使用白名单和标签过滤：
+
+```bash
+# 从白名单中选择，再排除进阶内容
+python tools/pdf_export/export_to_pdf.py \
+  --entry-list my-selection.txt \
+  --exclude-tags "进阶内容" \
+  --output MPS_Wiki_Custom.pdf
+```
+
+### 推荐的精简版配置
+
+**新手入门版**（适合初次了解的读者）：
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "基础概念,入门指南,常见问题" \
+  --output MPS_Wiki_Beginner.pdf
+```
+
+**临床专业版**（适合心理健康专业人士）：
+```bash
+python tools/pdf_export/export_to_pdf.py \
+  --include-tags "临床诊断,治疗方法,评估工具" \
+  --output MPS_Wiki_Professional.pdf
+```
+
+**核心手册版**（精选最重要的词条）：
+```bash
+# 先创建核心词条列表
+# 然后使用白名单导出
+python tools/pdf_export/export_to_pdf.py \
+  --entry-list core-entries.txt \
+  --output MPS_Wiki_Handbook.pdf
+```

--- a/tools/pdf_export/example-lite-entries.txt
+++ b/tools/pdf_export/example-lite-entries.txt
@@ -1,0 +1,45 @@
+# 精简版 PDF 词条白名单示例
+# 此文件展示如何创建词条白名单来生成精简版 PDF
+# 使用方法: python tools/pdf_export/export_to_pdf.py --entry-list tools/pdf_export/example-lite-entries.txt --output MPS_Wiki_Lite.pdf
+
+# ===== 基础概念 =====
+# 这些是理解 MPS 的核心概念
+Alter.md
+DID.md
+OSDD.md
+Dissociative-Disorders.md
+Multiple-System.md
+
+# ===== 系统运作 =====
+# 系统日常运作的基础知识
+Switch.md
+Front-Fronting.md
+Co-Fronting.md
+Co-Consciousness.md
+Inner-World.md
+
+# ===== 角色类型 =====
+# 常见的系统成员角色
+Host.md
+Protector.md
+Gatekeeper.md
+Inner-Self-Helper-ISH.md
+
+# ===== 临床与诊断 =====
+# 临床诊断相关的重要信息
+Trauma.md
+PTSD.md
+C-PTSD.md
+Grounding.md
+
+# ===== 创造型系统 =====
+# Tulpa 和创造型系统相关
+Tulpa.md
+Tulpamancy.md
+Plurality.md
+
+# 提示：
+# 1. 每行一个词条，可以使用文件名（推荐）或词条标题
+# 2. 使用 # 开头的行为注释，会被忽略
+# 3. 空行也会被忽略
+# 4. 可以根据需要添加或删除词条

--- a/tools/pdf_export/pdf_export/cli.py
+++ b/tools/pdf_export/pdf_export/cli.py
@@ -115,6 +115,24 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_COVER_FOOTER,
         help=f"封面底部文字 (默认: {DEFAULT_COVER_FOOTER})。传入空字符串可移除。",
     )
+    parser.add_argument(
+        "--include-tags",
+        type=str,
+        default=None,
+        help="只导出包含指定标签的词条，多个标签用逗号分隔。例如: --include-tags '基础概念,入门指南'",
+    )
+    parser.add_argument(
+        "--exclude-tags",
+        type=str,
+        default=None,
+        help="排除包含指定标签的词条，多个标签用逗号分隔。例如: --exclude-tags '进阶内容,实验性'",
+    )
+    parser.add_argument(
+        "--entry-list",
+        type=Path,
+        default=None,
+        help="指定词条白名单文件路径，每行一个词条文件名（如 'Alter.md'）或标题",
+    )
 
     return parser.parse_args(argv)
 
@@ -155,7 +173,22 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     if sys.stdout.isatty():
         print("📚 收集 Markdown 文件结构...")
-    preface_doc, structure = collect_markdown_structure(ignore_rules)
+
+    # 解析标签过滤参数
+    include_tags = None
+    if args.include_tags:
+        include_tags = set(tag.strip() for tag in args.include_tags.split(',') if tag.strip())
+
+    exclude_tags = None
+    if args.exclude_tags:
+        exclude_tags = set(tag.strip() for tag in args.exclude_tags.split(',') if tag.strip())
+
+    preface_doc, structure = collect_markdown_structure(
+        ignore_rules,
+        include_tags=include_tags,
+        exclude_tags=exclude_tags,
+        entry_list_path=args.entry_list,
+    )
     if not structure:
         raise SystemExit("没有找到可以导出的 Markdown 文件。")
 


### PR DESCRIPTION
## 功能概述

为 PDF 导出工具添加灵活的词条筛选功能，支持创建精简版 PDF，满足不同读者群体的需求。

## 主要变更

### 新增功能

- ✨ **标签筛选**：
  - `--include-tags`: 只导出包含指定标签的词条
  - `--exclude-tags`: 排除包含指定标签的词条
  - 支持多个标签组合，逗号分隔

- 📋 **白名单模式**：
  - `--entry-list`: 支持从文件读取词条列表
  - 支持文件名（如 `Alter.md`）和标题（如 `人格（Alter）`）两种格式
  - 支持 `#` 注释行

- 🔄 **组合过滤**：
  - 可同时使用白名单和标签过滤
  - 过滤逻辑清晰：白名单 → include-tags → exclude-tags

### 文档更新

- 📖 在 [README_pdf_output.md](tools/pdf_export/README_pdf_output.md) 添加完整的精简版使用文档
- 🚀 新增 [LITE_VERSION_GUIDE.md](tools/pdf_export/LITE_VERSION_GUIDE.md) 快速入门指南
- 📄 提供 [example-lite-entries.txt](tools/pdf_export/example-lite-entries.txt) 示例白名单文件

### 代码改进

- 优化 `structure.py` 的文档过滤逻辑
- 改进 CLI 参数处理
- 添加过滤统计信息输出

## 使用示例

### 按标签筛选
```bash
# 新手入门版
python tools/pdf_export/export_to_pdf.py \
  --include-tags "基础概念,入门指南" \
  --output MPS_Wiki_Beginner.pdf
```

### 使用白名单
```bash
# 核心手册版
python tools/pdf_export/export_to_pdf.py \
  --entry-list example-lite-entries.txt \
  --output MPS_Wiki_Core.pdf
```

### 组合使用
```bash
# 从白名单中选择，再排除进阶内容
python tools/pdf_export/export_to_pdf.py \
  --entry-list my-selection.txt \
  --exclude-tags "进阶内容" \
  --output MPS_Wiki_Custom.pdf
```

## 测试情况

- ✅ 标签过滤功能正常
- ✅ 白名单功能正常
- ✅ 组合过滤功能正常
- ✅ 兼容原有完整导出功能

## 相关 Issue

解决了大文件 PDF 导出的问题，允许创建针对特定读者群体的精简版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)