### PR TITLE
feat: 新增记忆回退词条

### DIFF
--- a/docs/entries/Memory-Rollback.md
+++ b/docs/entries/Memory-Rollback.md
@@ -1,0 +1,129 @@
+---
+comments: true
+description: 记忆回退描述的是解离性系统在强触发下短暂被“拉回”旧有时间线,以过往记忆框架体验当下,常伴现实定向混乱与情绪泛洪。本条目梳理机制、风险与稳定化策略,并区分退行等相似概念。
+synonyms:
+
+- 记忆回退
+- Memory Rollback
+- Memory Reversion
+- jiyi huitui
+
+tags:
+
+- ops:系统运作
+- sx:创伤症状
+- dx:解离障碍
+
+title: 记忆回退（Memory Rollback）
+topic: 系统运作
+updated: 2025-10-22
+---
+
+# 记忆回退（Memory Rollback）
+
+!!! info "术语状态｜社群/经验性术语"
+    “记忆回退”并非《DSM-5-TR》或《ICD-11》中的正式诊断术语，而是多意识体社群与临床经验中用于描述 **时间定向突然退回既往记忆框架** 的现象。撰写病例或法证文件时，应使用相应的诊断描述（如闪回、解离性遗忘、解离性身份障碍）。
+
+!!! warning "安全提醒"
+    记忆回退可能伴随强烈的情绪泛洪、现实感混乱与功能骤降。若出现失时、失控或自伤风险，请立即启动系统既定的安全计划，必要时联系持证专业人员或危机干预资源。
+
+---
+
+## 概述
+
+**记忆回退** 指系统成员在强触发或深层处理时，**短暂以过去某一时间点的记忆结构来体验当下**：主观上仿佛回到旧场景、旧年龄或旧人际定位，但环境并未真正改变。与[闪回（Flashback）](Flashback.md)的“创伤事件重现”不同，记忆回退更强调 **身份/情节记忆框架整体迁移**，常伴随谁在前台、当前年份等现实定向的模糊。[^vdh2006]
+
+在结构性解离模型中，记忆回退可理解为 **不同身份状态的记忆分隔被暂时“覆盖”当下体验**，导致前台成员失去现时背景，转而以过去版本的身份脚本行事。此时系统可能出现：
+
+- 功能性退化（语言、姿态、知识水平回到旧版本）
+- 与现实不匹配的称呼或人际反应
+- 对近期事件缺乏访问权限，或用旧记忆填补空白
+- 触发事件结束后逐步恢复，但可能伴随失时或片段性记忆缺失
+
+---
+
+## 形成机制
+
+### 1. 状态依赖与结构性解离
+
+创伤经历常以 **状态依赖性记忆** 储存：只有在相似情绪/生理状态下才能检索。[^brew2001] 当外部线索或内部加工进入该状态时，相关身份状态（如情感部分 EP）接管前台，使记忆网络整体“加载”，即表现为记忆回退。[^vdh2006]
+
+### 2. 叙事记忆与感官记忆的失衡
+
+创伤记忆倾向以碎片化的感官编码存在，缺乏整合后的叙事脉络。[^schauer2010] 当系统缺乏稳定化时，感官记忆泛洪会压制当下认知资源，成员转而依赖旧叙事脚本解释当下，出现“我们又回到了当年”的体验。
+
+### 3. 情绪调节与神经网络失整合
+
+PTSD/CPTSD 患者在海马-前额叶网络调节受损时，更易出现情绪泛洪与时间错位。[^lanius2010] 对多意识体系统来说，这种神经调节失衡会强化身份间的隔阂，使任何带有强情绪负荷的处理都可能触发回退。
+
+---
+
+## 典型表现
+
+| 维度 | 常见特征 | 风险指示 |
+| --- | --- | --- |
+| 时间感 | 自述“今天又是 20XX 年”“我们还在高中”等，难以校准现实时钟 | 对现实年份、地点完全失去定向需紧急稳定 |
+| 身份脚本 | 语言、姿态、习惯恢复为过去的版本，可能重新使用旧名、旧角色 | 若旧脚本包含自伤或危险行为，应立即介入 |
+| 记忆访问 | 当前事件被旧记忆取代或“缺席”，恢复后出现片段缺失 | 失时超过 1 小时或伴高风险行为需记录并评估 |
+| 情绪 | 与过去事件相符的恐惧/愤怒/羞耻泛洪，难以被当下事实调节 | 情绪强度无法缓解时需暂停加工，回到接地 |
+
+---
+
+## 与相近现象的区别
+
+| 对比项目 | 记忆回退（Memory Rollback） | 退行（Regression） | 闪回（Flashback） |
+| --- | --- | --- | --- |
+| 核心机制 | 记忆/身份框架被旧版本覆盖 | 情绪或行为水平暂时低龄化 | 创伤情境的感官再体验 |
+| 主观时间 | 感觉当下就是过去的某一天 | 保留当下时间，但以儿童/早期模式回应 | 仿佛事件正在发生，但多能事后辨识为记忆 |
+| 功能影响 | 当前信息处理受阻，需重新建立定向 | 可能寻求照料、语言语调儿童化 | 常伴强烈恐惧、警觉反应 |
+| 典型触发 | 旧场景、人物、味道；深度创伤加工 | 压力、依恋需求、情绪失调 | 创伤线索、睡眠剥夺、躯体反应 |
+| 干预重点 | 现实定向、内部沟通、权限管理 | 安全环境、需求回应、逐步回归成人功能 | 接地技巧、降低触发、循序暴露 |
+
+> **提示**：“退行”可作为记忆回退的背景条件（如成员在退行状态下易被旧记忆主导），但两者并非同义。退行关注 **情绪发展水平** 的回落，而记忆回退强调 **身份记忆结构的整体迁移**。
+
+---
+
+## 应对与稳定化策略
+
+### 1. 立即措施
+
+- **现实定向**：温和提醒当前日期、地点、年龄，可结合感官接地（触摸、闻味道）强化当下感。参照《[接地（Grounding）](Grounding.md)》。
+- **安全脚本**：提前准备“如果我们又回到旧时间线”的应对卡片，由守门人或照护成员朗读。
+- **权限管理**：守门人确认前台是否由具备成人功能的成员协助，共同完成基本生活任务。参见《[守门人（Gatekeeper）](Gatekeeper.md)》《[权限（Permissions）](Permissions.md)》。
+
+### 2. 事后整合
+
+- **记录差异**：通过[内部沟通](Internal-Communication.md)记录回退期间的认知/行为差异，帮助成员辨识触发链。
+- **情绪调节**：使用[接地](Grounding.md)、[躯体调节](Somatic-Experiencing-SE.md)或[正念](Mindfulness.md)技术，让神经系统回到可容忍窗。
+- **渐进加工**：在稳定阶段之外推进创伤处理（如[EMDR](Eye-Movement-Desensitization-Reprocessing-EMDR.md)、[TF-CBT](Trauma-Focused-Cognitive-Behavioral-Therapy-TF-CBT.md)），并由治疗师监测是否出现失控回退。[^isstd2011]
+
+### 3. 风险情境中的特别注意
+
+- **法证与医疗环境**：避免在缺乏支持的场域强行访问创伤记忆，以免触发回退导致陈述混乱或二次创伤。
+- **自助探索限制**：不建议使用诱导性催眠或“恢复记忆”技术尝试找回被封存的片段，研究显示此类方法风险高且易产生虚假记忆。[^loftus2019]
+- **共治计划**：与治疗团队制定“回退红旗”指标（如失时>30 分钟、自伤意念出现），达标即暂停所有深度加工，回到稳定化与日常功能恢复。
+
+---
+
+## 与系统协作的关系
+
+- **与守门人协作**：守门人可在触发早期识别“时间错位”迹象，提前切换到具备定向能力的成员，或安排内部安全区提供支持。
+- **角色分工调整**：若某些成员频繁回退，需检视其角色是否承载超出容忍范围的记忆或任务，评估是否能分担或建立缓冲机制。
+- **外部支持者教育**：向信任的外部伙伴说明记忆回退的表现与需要的协助（保持平静、提醒当下、避免争辩过去是否真实），减少误解与冲突。
+
+---
+
+## 进一步阅读
+
+- [退行（Regression）](Regression.md)：理解情绪/行为退行对系统运作的影响。
+- [记忆屏蔽（Memory Shielding）](Memory-Shielding.md)：当系统主动限制记忆流动时的策略与风险。
+- [侵入性记忆](Intrusive-Memory.md)、[闪回（Flashback）](Flashback.md)：区分不同类型的记忆侵入。
+
+---
+
+[^vdh2006]: van der Hart, O., Nijenhuis, E. R. S., & Steele, K. (2006). *The Haunted Self: Structural Dissociation and the Treatment of Chronic Traumatization*. W. W. Norton & Company.
+[^brew2001]: Brewin, C. R. (2001). A cognitive neuroscience account of posttraumatic stress disorder and its treatment. *Behaviour Research and Therapy*, 39(4), 373-393.
+[^schauer2010]: Schauer, M., & Elbert, T. (2010). Dissociation following traumatic stress. *Zeitschrift für Psychologie/Journal of Psychology*, 218(2), 109-127.
+[^lanius2010]: Lanius, R. A., Frewen, P. A., Vermetten, E., & Yehuda, R. (2010). Fear conditioning and early life vulnerabilities: Two distinct pathways of emotional dysregulation and brain dysfunction in PTSD. *European Journal of Psychotraumatology*, 1(1), 5467.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision*. *Journal of Trauma & Dissociation*, 12(2), 115–187.
+[^loftus2019]: Loftus, E. F. (2019). Eyewitness testimony, memory biases, and recovered memories. *Annual Review of Clinical Psychology*, 15, 241-263.

--- a/docs/guides/System-Operations-Guide.md
+++ b/docs/guides/System-Operations-Guide.md
@@ -65,6 +65,7 @@ search:
 - 🎨 [内视（Visualization / Imagination）](../entries/Visualization-Imagination.md)：心像支持沟通与记忆。
 - 🧳 [独有记忆（Exomemory）](../entries/Exomemory.md)：非当前生命史的叙事性记忆体验之机制与处理。
 - 🛡️ [记忆屏蔽（Memory Shielding）](../entries/Memory-Shielding.md)：何时建立屏障、如何安全解除。
+- 🔄 [记忆回退（Memory Rollback）](../entries/Memory-Rollback.md)：当下体验被旧记忆框架覆盖时的定向与安全策略。
 - 🧷 [独立性（Independence）](../entries/Independence.md)：评估成员自主程度与界限。
 - 🌡️ [存在感（Sense of Presence）](../entries/Sense-Of-Presence.md)：在场与否的体感线索。
 - 🧪 [功能性分离（Functional Dissociation）](../entries/Functional-Dissociation.md)：区分工作分流与病理性解离。


### PR DESCRIPTION
## Summary
- 新增「记忆回退（Memory Rollback）」词条，梳理概念定义、触发机制与风险应对，并区分退行与闪回
- 在《系统运作导览》中补充记忆回退的索引说明，便于关联查阅

## Testing
- python3 tools/check_links.py docs/entries/Memory-Rollback.md
- python3 tools/check_links.py docs/entries/
- python3 tools/check_tags.py docs/entries/Memory-Rollback.md
- python3 tools/check_tags.py docs/entries/


------
https://chatgpt.com/codex/tasks/task_e_68f9e3c6d99c83338d0c2ef6ccf3a734