### PR TITLE
feat: 新增灾难预演词条

### DIFF
--- a/docs/entries/Disaster-Rehearsal.md
+++ b/docs/entries/Disaster-Rehearsal.md
@@ -1,0 +1,165 @@
+---
+comments: true
+description: 灾难预演指在高度焦虑或创伤警觉下，脑中自动上演未来恐惧情境的侵入性影像，常发生于临睡或清醒过渡期。词条解析其定义、与闪回及侵入性思维的差异、典型触发、维持机制与干预策略。
+search:
+  boost: 1.3
+synonyms:
+  - 灾难预演
+  - 灾难性预演
+  - 未来侵入性意象
+  - flashforward imagery
+  - catastrophic rehearsal
+  - future-oriented intrusive imagery
+  - zai'nan yuyan
+  - zai'nan yuyan yi'xiang
+  - flashforward intrusions
+  - prospective intrusive imagery
+  - future flashforward
+  - 灾难预演画面
+  - 灾难预演影像
+  - 灾难预演意象
+  - 灾难预演体验
+tags:
+  - sx:系统运作
+  - sx:创伤症状
+  - dx:创伤后应激障碍
+  - dx:焦虑障碍
+title: 灾难预演（Disaster Rehearsal / Flashforward Imagery）
+topic: 系统运作
+updated: 2025-10-29
+---
+
+# 灾难预演（Disaster Rehearsal / Flashforward Imagery）
+
+!!! warning "触发警告"
+    词条涉及创伤、灾难场景、焦虑与自伤/他伤意象等敏感内容，阅读时请留意自身状态，必要时准备[接地](Grounding.md)资源或与信任对象同在。
+
+!!! info "免责声明"
+    本站内容仅供教育用途，不能替代专业评估或治疗。如出现高危念头、失控行为或显著功能受损，请及时寻求持证专业人员帮助。
+
+---
+
+## 概述
+
+> **一句话摘要**：灾难预演是指在强烈压力或高度警觉下，大脑自动“预演”未来灾难情景的侵入性影像/场景，常伴失控感与即时躯体反应。
+
+**灾难预演**（flashforward imagery、catastrophic rehearsal）是一种 **面向未来的侵入性意象**：当事人在无意识触发下，脑中突然浮现高度逼真、反复的灾难画面（如事故、暴力、溺亡、崩溃），仿佛“正在经历未来的最坏结果”。它常出现在睡眠前后、半梦半醒、极度疲惫或强烈担忧时，既可见于创伤相关障碍，也出现在广泛性焦虑、强迫症、抑郁症与自杀风险评估中。[^hirsch2007] [^holmes2009]
+
+---
+
+## 核心特征
+
+> **关键词**：未来导向、高沉浸度、情境化、伴生生理反应、失控感。
+
+- **时间指向未来**：场景通常描绘“可能发生”的灾难，而非既往记忆的重播。
+- **高度逼真**：包含视觉、听觉、嗅觉、躯体感觉等多模态，仿佛在亲历预演。
+- **情绪/生理激活**：心率、呼吸、肌肉紧绷与恐惧、绝望感同步上升。
+- **认知共鸣**：常伴“事情一定会发生”“我无法阻止”等灾难化信念。
+- **反复闯入**：即便试图转移注意力，影像仍以片段或完整剧情反复出现。
+
+---
+
+## 常见触发情境
+
+1. **睡眠-清醒过渡**：半梦半醒、入睡困难或惊醒时的安全感缺口。
+2. **外部线索**：新闻、社交媒体、气味、声音等使人联想到恐惧未来的刺激。
+3. **内部压力**：高负荷工作、考试、社交冲突或家庭责任导致的焦虑预期。
+4. **创伤警觉**：创伤幸存者在面对类似环境/人际情境时的安全扫描反应。
+5. **自责/责任感**：担心无法保护家人、无法履职而反复“模拟失败后果”。
+
+---
+
+## 与闪回、侵入性思维的快速区分
+
+> **对照表**：请结合下表判断当下体验属于哪一类侵入现象，并据此选择合适的应对策略。
+
+| 现象 | 时间指向 | 核心体验 | 典型触发 | 现实定向 | 关键词 | 推荐参阅 |
+| --- | --- | --- | --- | --- | --- | --- |
+| **灾难预演** | 未来 | 自动上演最坏结果的沉浸式影像，常伴“无法阻止”感 | 压力、半梦半醒、责任焦虑、创伤警觉 | 多数保留当下感，但注意力被未来场景占满 | “如果…就会毁灭” | 本文 |
+| [**闪回**](Flashback.md) | 过去 | 重返创伤现场的全感官再体验，“仿佛正在发生” | 创伤线索、感官刺激、睡眠再现 | 当下感显著削弱或短暂丧失 | “它又发生了” | [闪回](Flashback.md) |
+| [**侵入性思维**](Intrusive-Thoughts.md) | 未来或当下 | 突兀的不受欢迎想法/片段，可伴图像或语句 | 注意偏向、价值冲突、强迫循环 | 现实定向大多完整，内容多为语言或短图像 | “不想想到它” | [侵入性思维](Intrusive-Thoughts.md) |
+
+!!! tip "实践建议"
+    - **区分目的**：辨识类别有助于选择合适的接地、认知重构或暴露策略。
+    - **可共存**：灾难预演可与闪回或侵入性思维交替出现，需综合评估安全计划。
+
+---
+
+## 产生与维持机制
+
+- **灾难化预期与注意偏向**：持续扫描威胁使大脑生成“模拟场景”以备最坏情况，反而巩固恐惧。[^hirsch2007]
+- **想象增强效应**：意象较文字更具情绪动员力，促使交感神经激活，形成“越怕越想”的循环。[^holmes2009]
+- **意象记忆混淆**：频繁预演削弱“计划”与“现实”的界线，提升现实感。
+- **睡眠剥夺与梦境残余**：进入/退出 REM 时的脑波与肌肉抑制易让灾难意象延伸至清醒状态。[^valli2011]
+- **系统协作因素**：多意识体系统中，负责风险管理的成员可能在夜间接管前台进行“演练”，若缺乏内部沟通会造成群体惊慌。
+
+---
+
+## 风险评估与红旗讯号
+
+- **自/他伤情节**：灾难预演中出现具体、自我伤害或伤害他人的执行步骤。
+- **行动冲动**：意象触发即刻行动冲动（如冲出门、抓紧武器），需快速接地与安全计划。
+- **现实混淆**：难以判断场景是否真实发生，伴随定向障碍，应评估闪回/解离共病。
+- **共病严重度**：若与[广泛性焦虑障碍（GAD）](Generalized-Anxiety-Disorder-GAD.md)、[PTSD](PTSD.md)、[抑郁障碍](Depressive-Disorders.md)等症状同时加剧，应寻求专业支持。
+
+---
+
+## 应对与自助策略
+
+1. **接地与感官回到当下**：使用 5-4-3-2-1 感官练习、冰敷、深呼吸或肌肉放松，将注意力从意象拉回身体。
+2. **情绪标记**：将意象内容、强度、情绪写在记录本中，标注“这只是影像，不是事实”，巩固现实检验。
+3. **计划 vs. 演练区分**：列出可执行的风险管理步骤，将“灾难剧本”拆解为具体可控行动，以减少反复想象。
+4. **睡眠卫生**：建立固定睡前仪式、减少蓝光与刺激性内容、安排放松练习，降低半梦半醒时段的触发。
+5. **系统内部沟通**：如为多意识体系统，明确“哪位成员负责风险评估、哪位负责安抚”，避免集体灾难预演。
+
+!!! warning "何时寻求专业协助"
+    - 影像频率/强度不断提升
+    - 影响睡眠、工作与人际功能
+    - 伴随自伤或他伤冲动
+    - 影像失控，难以回到现实定向
+
+---
+
+## 治疗与干预方向
+
+- **认知行为疗法（CBT）**：聚焦灾难化思维、思想-行动融合与意象重构，训练区分概率与可能性。[^clark2011]
+- **意象重塑与暴露（Imagery Rescripting / IE）**：在专业带领下重新设计结局、赋予掌控感，减少灾难预演的情绪强度。[^arnzt2013]
+- **正念与接受疗法（ACT）**：练习与影像共处而不被吞没，降低反刍与回避循环。[^hayes2012]
+- **药物辅助**：若伴随 GAD、PTSD 或抑郁障碍，可在医师评估下使用 SSRI/SNRI、羟嗪等以降低基线焦虑。
+- **危机计划**：与治疗师或支持系统制定“影像出现时的即时行动表”，确保安全。
+
+---
+
+## 多意识体系统的实务建议
+
+- **角色分工**：区分“预警者”与“执行者”，避免所有成员被迫观看灾难演练。
+- **共享日志**：建立内部日志记录触发因素、应对效果，协助识别可调整的外部条件。
+- **协作接地**：指定备用成员在灾难预演时进行接地或与外部支持联系。
+- **治疗沟通**：提前与治疗师讨论灾难预演现象，以便在安全环境下进行意象暴露或重塑。
+
+---
+
+## 参阅
+
+- [闪回（Flashback）](Flashback.md)
+- [侵入性思维（Intrusive Thoughts）](Intrusive-Thoughts.md)
+- [侵入性记忆（Intrusive Memory）](Intrusive-Memory.md)
+- [广泛性焦虑障碍（Generalized Anxiety Disorder, GAD）](Generalized-Anxiety-Disorder-GAD.md)
+- [接地（Grounding）](Grounding.md)
+- [危机与支持资源](Crisis-And-Support-Resources.md)
+
+---
+
+## 参考文献
+
+[^hirsch2007]: Hirsch, C. R., & Holmes, E. A. (2007). Mental imagery in anxiety disorders. *Journal of Behavior Therapy and Experimental Psychiatry*, 38(4), 405–413. https://doi.org/10.1016/j.jbtep.2007.08.001
+
+[^holmes2009]: Holmes, E. A., Mathews, A., Dalgleish, T., & Mackintosh, B. (2009). Positive interpretation training: Effects of mental imagery versus verbal training on anticipated future events in anxiety. *Behaviour Research and Therapy*, 47(3), 237–244. https://doi.org/10.1016/j.brat.2008.12.005
+
+[^valli2011]: Valli, K., & Revonsuo, A. (2011). Dreaming and consciousness: Testing the threat simulation theory of the function of dreaming. *Consciousness and Cognition*, 20(4), 995–1007. https://doi.org/10.1016/j.concog.2010.12.003
+
+[^clark2011]: Clark, D. A., & Beck, A. T. (2011). Cognitive therapy of anxiety disorders: Science and practice. Guilford Press.
+
+[^arnzt2013]: Arntz, A. (2013). Imagery rescripting for personality disorders. *Cognitive and Behavioral Practice*, 20(3), 266–281. https://doi.org/10.1016/j.cbpra.2013.04.006
+
+[^hayes2012]: Hayes, S. C., Strosahl, K. D., & Wilson, K. G. (2012). *Acceptance and Commitment Therapy: The Process and Practice of Mindful Change* (2nd ed.). Guilford Press.

--- a/docs/entries/Flashback.md
+++ b/docs/entries/Flashback.md
@@ -52,6 +52,7 @@ updated: 2025-10-22
     - 与一般侵入性思维：闪回具有多模态感知（视觉、听觉、嗅觉、触觉）与沉浸感，超越单纯"想起"
     - 与解离：闪回是记忆"过度激活"，解离是意识"整合中断"；可共存但机制不同
     - 与幻觉：闪回与创伤线索相关、事后可识别为记忆，精神病性幻觉缺乏此模式且伴现实检验受损
+    - 与灾难预演：灾难预演面向未来、模拟最坏结果，现实定向通常保留；详见[灾难预演（Disaster Rehearsal）](Disaster-Rehearsal.md)
 
     **治疗原则**：**阶段一**（稳定）：接地技巧、触发管理、安全环境 → **阶段二**（创伤加工）：TF-CBT、PE、EMDR（需充分稳定） → **阶段三**（整合）：功能恢复、预防复发
 
@@ -658,6 +659,7 @@ updated: 2025-10-22
 
 - [触发（Trigger）](Trigger.md)
 - [情绪调节（Emotion Regulation）](Emotion-Regulation.md)
+- [灾难预演（Disaster Rehearsal）](Disaster-Rehearsal.md)
 
 ---
 

--- a/docs/entries/Intrusive-Thoughts.md
+++ b/docs/entries/Intrusive-Thoughts.md
@@ -124,8 +124,9 @@ SSRI 等对伴随 OCD/焦虑/抑郁的侵入性思维有效。
 | 侵入性思维 | 非自愿闯入意识的不受欢迎想法/图像/冲动 | 各类主题（不一定与创伤相关） | 焦虑、羞愧、厌恶；多保留现实定向 |
 | 侵入性记忆 | 与创伤事件直接相关的记忆闯入 | 记忆片段/图像/片语 | 再体验、痛苦情绪，通常仍保持当下感 |
 | 闪回 | 强烈沉浸式再体验，仿佛“回到当时” | 场景级重现、全感官参与 | 当下感被削弱或丧失，可能出现定向障碍 |
+| [灾难预演](Disaster-Rehearsal.md) | 模拟未来最坏场景的沉浸式影像 | 未来灾难剧情、责任失败、自他伤画面 | 现实定向通常保留，但高度担忧与生理警觉 |
 
-参阅： [侵入性记忆（Intrusive Memory）](Intrusive-Memory.md) · [闪回（Flashback）](Flashback.md)
+参阅： [侵入性记忆（Intrusive Memory）](Intrusive-Memory.md) · [闪回（Flashback）](Flashback.md) · [灾难预演（Disaster Rehearsal）](Disaster-Rehearsal.md)
 
 !!! note "与注意状态的区分"
     侵入性思维是“不受欢迎且难以控制”的内容闯入；而[过度专注（Hyperfocus）](Hyperfocus.md)/[心流（Flow）](Flow.md)属于注意状态，前者常为被动“黏附”、抽离困难，后者为主动、可控且与目标一致的积极体验。
@@ -142,6 +143,7 @@ SSRI 等对伴随 OCD/焦虑/抑郁的侵入性思维有效。
 
 - [侵入性记忆（Intrusive Memory）](Intrusive-Memory.md)
 - [闪回（Flashback）](Flashback.md)
+- [灾难预演（Disaster Rehearsal）](Disaster-Rehearsal.md)
 - [强迫症（OCD）](OCD.md)
 - [解离](Dissociation.md)
 - [应激反应](Stress-Response.md)
@@ -154,6 +156,7 @@ SSRI 等对伴随 OCD/焦虑/抑郁的侵入性思维有效。
 - [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](PTSD.md)
 - [强迫症（Obsessive-Compulsive Disorder, OCD）](OCD.md)
 - [闪回（Flashback）](Flashback.md)
+- [灾难预演（Disaster Rehearsal）](Disaster-Rehearsal.md)
 - [非我感（Depersonalization）](Not-Me-Feeling.md)
 - [心境障碍（Affective Disorders）](Affective-Disorders.md)
 - [抑郁障碍（Depressive Disorders）](Depressive-Disorders.md)

--- a/docs/guides/System-Operations-Guide.md
+++ b/docs/guides/System-Operations-Guide.md
@@ -74,6 +74,7 @@ search:
 - 🧸 [退行（Regression）](../entries/Regression.md)：区分年龄退行与儿童人格的功能。
 - 💭 [侵入性思维](../entries/Intrusive-Thoughts.md)：应对突发的念头、影像或语句；区分侵入性记忆与闪回。
 - 🧠 [侵入性记忆](../entries/Intrusive-Memory.md)：创伤相关的记忆闯入，区分与闪回、思维。
+- ⚠️ [灾难预演（Disaster Rehearsal）](../entries/Disaster-Rehearsal.md)：未来导向的灾难性意象；比较闪回、侵入性思维并提供快速区分表。
 - 🎯 [过度专注（Hyperfocus）](../entries/Hyperfocus.md)：注意“黏附”与抽离困难；区分心流与解离，提供切换策略。
 - 🧊 [心流（Flow）](../entries/Flow.md)：主动、适配且可控的最佳专注体验；与过度专注、解离区分。
 - 🥴 [醉酒解离](../entries/Alcohol-Induced-Dissociation.md)：似醉非饮的主观体验与稳定策略。


### PR DESCRIPTION
## Summary
- 新增「灾难预演」词条，整理定义、触发因素、应对策略与快速区分表
- 在「闪回」「侵入性思维」词条补充灾难预演的差异说明与交叉链接
- 更新《系统运作导览》纳入灾难预演条目，完善侵入性体验导航

## Testing
- python3 tools/check_links.py docs/entries/
- python3 tools/check_tags.py docs/entries/


------
https://chatgpt.com/codex/tasks/task_e_6902b67c2dc08333afda1d59bbc0c486