### PR TITLE
feat: 为 MID-60 报表新增柱状图视图

### DIFF
--- a/docs/assets/mid60.css
+++ b/docs/assets/mid60.css
@@ -186,6 +186,129 @@
   position: relative; /* 便于导出时定位水印 */
 }
 
+.mid60-chart {
+  margin-top: .2rem;
+  display: flex;
+  flex-direction: column;
+  gap: .7rem;
+  padding: .85rem .75rem 1rem;
+  border-radius: .8rem;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 5%, transparent);
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+
+[data-md-color-scheme="slate"] .mid60-chart {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 12%, #1b2331);
+}
+
+.mid60-chart-group {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+}
+
+.mid60-chart-group-title {
+  margin: 0;
+  font-size: .85rem;
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+}
+
+.mid60-chart-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(5.3rem, 1fr));
+  gap: .6rem;
+  align-items: end;
+}
+
+.mid60-chart-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .3rem;
+  min-height: 11.5rem;
+}
+
+.mid60-chart-barwrap {
+  position: relative;
+  width: 100%;
+  height: 9rem;
+  border-radius: .65rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 12%, transparent);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0 .3rem;
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,.05);
+}
+
+[data-md-color-scheme="slate"] .mid60-chart-barwrap {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 18%, #121826);
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,.35);
+}
+
+.mid60-chart-bar {
+  width: 100%;
+  height: 0%;
+  border-radius: .45rem .45rem 0 0;
+  background: linear-gradient(180deg, #4fc08d, #3fb489);
+  transition: height .3s ease, background .3s ease;
+}
+
+.mid60-chart-cutoff {
+  position: absolute;
+  left: .35rem;
+  right: .35rem;
+  bottom: 0;
+  height: .18rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--md-accent-fg-color) 45%, transparent);
+  opacity: .75;
+}
+
+.mid60-chart-value {
+  font-weight: 600;
+  font-size: .95rem;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: baseline;
+  gap: .1rem;
+}
+
+.mid60-chart-value .unit {
+  font-size: .75rem;
+  opacity: .75;
+}
+
+.mid60-chart-cutoff-text {
+  font-size: .7rem;
+  opacity: .72;
+  text-align: center;
+  min-height: 1rem;
+}
+
+.mid60-chart-label {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: .1rem;
+  font-size: .82rem;
+  line-height: 1.25;
+}
+
+.mid60-chart-label-sub {
+  font-size: .72rem;
+  opacity: .75;
+}
+
+.mid60-chart-item[data-state="high"] .mid60-chart-value {
+  color: #e94545;
+}
+
+.mid60-chart-item[data-state="normal"] .mid60-chart-value {
+  color: #2f8f70;
+}
+
 .mid60-progress {
   height: .8rem;
   border-radius: .6rem;
@@ -341,6 +464,20 @@
   .mid60-legend { font-size: .7rem; }
   .mid60-subgrid { grid-template-columns: 1fr; }
   .mid60-section-title { font-size: .95rem; }
+
+  .mid60-chart {
+    padding: .75rem .6rem .9rem;
+    gap: .6rem;
+  }
+
+  .mid60-chart-items {
+    grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
+    gap: .5rem;
+  }
+
+  .mid60-chart-barwrap {
+    height: 8.4rem;
+  }
 }
 
 /* 更窄屏进一步优化 */
@@ -399,4 +536,21 @@
   .mid60-ctrl input[type="range"] { width: 100%; min-width: 0; }
   .mid60-badge { width: 4.8rem; justify-self: end; align-self: center; }
   .mid60-subgrid { grid-template-columns: 1fr; }
+
+  .mid60-chart {
+    padding: .7rem .55rem .85rem;
+  }
+
+  .mid60-chart-items {
+    grid-template-columns: repeat(auto-fit, minmax(4.8rem, 1fr));
+    gap: .45rem;
+  }
+
+  .mid60-chart-barwrap {
+    height: 7.6rem;
+  }
+
+  .mid60-chart-item {
+    min-height: 10.5rem;
+  }
 }

--- a/docs/entries/Multidimensional-Inventory-of-Dissociation-MID-60.md
+++ b/docs/entries/Multidimensional-Inventory-of-Dissociation-MID-60.md
@@ -446,6 +446,10 @@ updated: 2025-10-21
   <div class="mid60-legend"><span>0</span><span>7</span><span>14</span><span>21</span><span>30</span><span>40</span><span>64</span><span>100</span></div>
   <div class="mid60-note">临床解读:<span id="mid60-level">无解离体验</span></div>
 
+  <div class="mid60-section-title">柱状图报表</div>
+  <div class="mid60-hint">红色柱状代表超过临界值，绿色柱状代表临界值以下，适合手机端与电脑端一屏截图。</div>
+  <div id="mid60-chart" class="mid60-chart" aria-label="MID-60 柱状图报表"></div>
+
   <!-- 安全提示：当 22/44/58 任一题较高时由脚本显示 -->
   <div id="mid60-safety-alert" class="admonition warning" style="display:none">
     <p class="admonition-title">安全提示</p>


### PR DESCRIPTION
## Summary
- 引入子量表元数据与柱状图构建逻辑，移动端和桌面端统一展示超临界红色、临界内绿色的柱状图
- 为 MID-60 专用样式增加柱状图栅格、柱体与阈值标识的视觉表现及响应式优化
- 在 MID-60 词条结果区加入柱状图容器与提示文案，便于一屏截图

## Testing
- python3 tools/check_links.py docs/entries/
- python3 tools/check_tags.py docs/entries/


------
https://chatgpt.com/codex/tasks/task_e_6906ee572c1c8333b9899fd84bc69f30