### PR TITLE
feat: 新增 ANP–EP 混溶词条

### DIFF
--- a/docs/entries/ANP-EP-Blending.md
+++ b/docs/entries/ANP-EP-Blending.md
@@ -1,0 +1,139 @@
+---
+comments: true
+description: 描述结构性解离框架下表面正常部分与情绪部分边界暂时融混的现象，说明识别特征、诱因、临床风险与系统自助策略。
+synonyms:
+  - ANP-EP 混融
+  - 表面正常部分-情绪部分混合
+  - ANP–EP Blending
+  - ANP/EP 混溶
+
+tags:
+  - ops:系统运作
+  - theory:结构性解离
+  - sx:共意识
+
+title: ANP–EP 混溶（ANP–EP Blending）
+topic: 系统运作
+updated: 2025-10-23
+---
+
+# ANP–EP 混溶（ANP–EP Blending）
+
+**一句话定义**：ANP–EP 混溶指结构性解离模型中，表面正常部分（ANP）与情绪部分（EP）的功能边界在短时间内模糊、彼此渗透的状态，表现为“日常执行者”与“创伤反应者”同时影响前台意识与行为。
+
+!!! info "术语定位"
+    - **来源**：基于[结构性解离理论](Structural-Dissociation-Theory.md)与[ANP-EP 模型](Apparently-Normal-Part-Emotional-Part-Model.md)的临床/现象学描述。
+    - **性质**：现象级别语言，非 ICD/DSM 诊断术语；与社群用语“混合（Blending）”相关但范围更窄，聚焦 ANP/EP 功能。
+    - **适用情境**：复杂 PTSD、OSDD、DID 或其他呈现 ANP/EP 功能分化的系统；需结合个案评估，避免泛化到所有多意识体验。
+
+---
+
+## 概述
+
+结构性解离理论指出，长期创伤可让负责日常生存的 ANP 与承载创伤记忆、防御反应的 EP 形成功能性分化。[^vanderhart2006] 当两者因触发、疲惫或治疗探索而短暂“融成一团”时，便出现 **ANP–EP 混溶**：
+
+- ANP 仍试图维持现实定向与社会角色，但其语气、姿态与情绪被 EP 的感受渗透；
+- EP 将情绪或感官记忆推向前台，却未完全取得控制，导致“像在看自己做事”；
+- 观察者常描述为“我既在上班又在重播创伤”，或“身体在动但情绪停留在过去”。
+
+这种状态在临床访谈中被记录为“交叠期”或“部分切换”，通常持续数秒至数分钟，若调节失败可能转为完整切换或解离性失能。[^loewenstein1991]
+
+---
+
+## 与相关概念的区分
+
+| 概念 | 核心差异 | 重点提醒 |
+| --- | --- | --- |
+| [混合（Blending）](Blending.md) | 可涉及任意成员；强调主观边界模糊 | ANP–EP 混溶限定于 ANP/EP 功能轴，常伴创伤情绪闯入日常任务 |
+| [共前台（Co-Fronting）](Co-Fronting.md) | 多人分工协作、边界清晰 | 混溶时分工不清，ANP/EP 互相干扰，难以明确职责 |
+| [切换（Switch）](Switch.md) | 控制权从 A 转 B 的过程 | 混溶是过程中的“重叠地带”或独立状态，可能反复在切换前后出现 |
+| [融合（Fusion）](Fusion.md) | 身份的永久整合 | 混溶是暂时现象，可逆、功能取向；不代表整合已完成 |
+
+---
+
+## 识别特征
+
+1. **双轨情绪**：外在言行符合 ANP 的日常角色，但语气、词汇或肢体出现 EP 的恐惧、愤怒、屈服姿态。[^steele2017]
+2. **认知分层**：ANP 描述“像在旁观自己的身体”，EP 则报告“我被拉去看现在发生的事”，两者都对同一事件留有片段记忆。
+3. **躯体混响**：同一时间出现“身体麻木 + 胸口疼”“眼前现实 + 闪回画面”等矛盾体验。
+4. **时间错位**：ANP 能报出当前日期，但 EP 的语句停留在创伤时空，导致对话里混入过去时态或儿童语气。
+5. **执行波动**：任务执行一会儿流畅、一会儿迟滞，类似“踩油门又踩刹车”，常伴头压、耳鸣或视觉变暗。
+
+---
+
+## 常见诱因
+
+- **触发记忆或防御反应**：回忆创伤、面对相似声音/气味、治疗提问“那时发生了什么”时，EP 的情绪与防御系统抢占注意力。[^vanderhart2006]
+- **情绪压抑过度**：ANP 长期压抑情绪、维持“完美功能”后，情绪容量被透支，EP 的体验被动泄漏。
+- **睡眠剥夺与生理压力**：睡眠不足、疾病或荷尔蒙波动会削弱 ANP 的执行功能，使 EP 更易贴近前台。[^brand2014]
+- **治疗中的合作练习**：在安全情境下主动练习合作（如共同写日志、共享感官体验）也可能短暂引发混溶，需要额外边界支撑。[^isstd2011]
+
+---
+
+## 功能影响与风险
+
+| 维度 | 潜在收益 | 潜在风险 |
+| --- | --- | --- |
+| **理解彼此** | ANP 直接感知 EP 的情绪与记忆，有助于建立同理与联合叙事 | 情绪洪水淹没 ANP，出现恐慌、泪崩或解离性麻木 |
+| **技能借用** | EP 的敏感度、直觉或身体记忆可协助任务（例如艺术创作） | 执行功能被打断，出现指令遗忘、驾驶/工作安全下降 |
+| **整合准备** | 阶段化治疗中，混溶可作为检验协作与安全计划的“练习场” | 若未稳定就加工创伤，可能再创伤化，诱发失忆或自伤冲动 |
+
+出现以下情形应视为高风险信号：
+
+- 现实定向丧失、无法辨认身边人事物；
+- 强烈的身体痛感、窒息感、抽搐；
+- 自伤或攻击冲动在 ANP 意识中“突然出现”；
+- 混溶持续超过数小时，影响进食、服药、照护责任。
+
+---
+
+## 应对策略
+
+### 稳定与定向
+
+1. **双通道接地**：同时使用感官（冰块、香味）与认知（报日期、列任务）工具，分别安抚 ANP 与 EP。参见[接地（Grounding）](Grounding.md)。
+2. **角色语言**：用“日常的我”“那个经历事情的我们”等词语确认双方都被听见，避免“谁才是真的”争执。
+3. **外部锚点**：准备写有“此刻任务/时间/联系人”的卡片，帮助 ANP 抓住现实；EP 则可手持软性物品或触觉玩具自我安抚。
+
+### 内部协议
+
+- **安全词**：若混溶难以承受，可由守门人或其他成员听到预设词后协助退场。参见[权限（Permissions）](Permissions.md)。
+- **共识记录**：在混溶平稳时，共同写下“何时允许共同在场”“谁负责把控身体”“遇到触发如何求助”。
+- **分段释放**：允许 EP 以书写、绘画、动作等方式分批表达，ANP 负责记录与安排休息，避免一次性“全部倒出”。
+
+### 治疗协作
+
+- **阶段化原则**：遵循“稳定化 → 创伤加工 → 整合”，在第一阶段建立基础调节能力后，再逐步探索混溶背后的记忆与意义。[^isstd2011]
+- **治疗师观察提示**：当来访者语调突变、眼神焦点飘移或同时使用“我/她/他们”指代自己时，可能正在混溶；此时可放慢节奏、加强定向。[^brand2014]
+- **创伤加工中的“踩刹车”**：如果 EMDR、感觉运动疗法等技术引发混溶过载，可使用“停止信号”与“安全意象”快速降强度。[^steele2017]
+
+---
+
+## 系统自查清单
+
+1. **混溶发生时谁在场？** 记录涉及成员、体感与情绪，以辨识模式。
+2. **当下任务能否暂停？** 若涉及驾驶、看护儿童等高风险任务，优先交接或求助。
+3. **我们已有的工具是什么？** 列出接地、日志、外部支持与治疗资源。
+4. **需要新增的支持？** 如“值班”成员、外部提醒装置、治疗师紧急计划。
+
+---
+
+## 相关条目
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](Apparently-Normal-Part-Emotional-Part-Model.md)
+- [结构性解离理论（Structural Dissociation Theory）](Structural-Dissociation-Theory.md)
+- [混合（Blending）](Blending.md)
+- [前台（Front / Fronting）](Front-Fronting.md)
+- [共前台（Co-Fronting）](Co-Fronting.md)
+- [切换（Switch）](Switch.md)
+- [接地（Grounding）](Grounding.md)
+
+---
+
+## 参考资料
+
+[^vanderhart2006]: Van der Hart, O., Nijenhuis, E. R. S., & Steele, K. (2006). *The Haunted Self: Structural Dissociation and the Treatment of Chronic Traumatization*. W. W. Norton.
+[^steele2017]: Steele, K., Boon, S., & van der Hart, O. (2017). *Treating Trauma-Related Dissociation: A Practical, Integrative Approach*. W. W. Norton.
+[^loewenstein1991]: Loewenstein, R. J. (1991). An Office Mental Status Examination for Complex Chronic Dissociative Symptoms and Multiple Personality Disorder. *Psychiatric Clinics of North America*, 14(3), 567–604.
+[^brand2014]: Brand, B. L., Loewenstein, R. J., & Spiegel, D. (2014). Dispelling myths about dissociative identity disorder treatment: An empirically based approach. *Psychiatry*, 77(2), 169–189.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision. *Journal of Trauma & Dissociation*, 12(2), 115–187.

--- a/docs/guides/System-Operations-Guide.md
+++ b/docs/guides/System-Operations-Guide.md
@@ -46,6 +46,7 @@ search:
 - 👥 [共前台（Co-Fronting）](../entries/Co-Fronting.md)：多人并行执掌的分工与风险。
 - 🌫️ [前台模糊（Front Blur）](../entries/Front-Blur.md)：无法确定谁在前台的状态识别与应对。
 - 🌀 [混合（Blending）](../entries/Blending.md)：（社群用语，非诊断）边界模糊、记忆渗透的识别与处置。
+- 🧪 [ANP–EP 混溶（ANP–EP Blending）](../entries/ANP-EP-Blending.md)：结构性解离语境下，日常执行者与创伤反应者暂时交叠时的识别与稳定策略。
 - 🧭 [并行（Parallelism）](../entries/Parallelism.md)：多条意识流同时运行时的负荷管理。
 - 🔙 [后台（Back / Being Back）](../entries/Back-Being-Back.md)：退到后台后的支持方式。
 - 🤖 [自动驾驶（Autopilot）](../entries/Autopilot.md)："机械操作"状态与恢复觉察。


### PR DESCRIPTION
## Summary
- 新增 ANP–EP 混溶詞條，說明 ANP 與 EP 在結構性解離中的混溶徵象、誘因與應對策略，並補充臨床參考來源
- 系統運作導覽加入 ANP–EP 混溶的索引節點，方便與混合/前台管理等詞條互相導航

## Testing
- python3 tools/check_links.py docs/entries/ANP-EP-Blending.md
- python3 tools/check_tags.py docs/entries/ANP-EP-Blending.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aae7b0e6c8333b89aeef031b1ea5f)