### PR TITLE
新增观察者 ANP 切换词条并扩展 ANP-EP 关联

### DIFF
--- a/docs/entries/ANP-EP-Blending.md
+++ b/docs/entries/ANP-EP-Blending.md
@@ -130,6 +130,7 @@ updated: 2025-11-17
 - [共前台（Co-Fronting）](Co-Fronting.md)
 - [切换（Switch）](Switch.md)
 - [接地（Grounding）](Grounding.md)
+- [观察者 ANP 切换（Observer ANP Switch）](Observer-ANP-Switch.md)
 
 ---
 

--- a/docs/entries/Apparently-Normal-Part-Emotional-Part-Model.md
+++ b/docs/entries/Apparently-Normal-Part-Emotional-Part-Model.md
@@ -409,6 +409,8 @@ ANP-EP 模型的治疗遵循国际创伤与解离研究学会（ISSTD）的三�
 - [自动驾驶（Autopilot）](Autopilot.md)
 - [共同意识（Co-Consciousness）](Co-Consciousness.md)
 - [融合（Fusion）](Fusion.md)
+- [ANP–EP 混溶（ANP–EP Blending）](ANP-EP-Blending.md)
+- [观察者 ANP 切换（Observer ANP Switch）](Observer-ANP-Switch.md)
 
 ### 创伤与疗愈
 

--- a/docs/entries/Observer-ANP-Switch.md
+++ b/docs/entries/Observer-ANP-Switch.md
@@ -1,0 +1,119 @@
+---
+comments: true
+description: 解释“观察者 ANP”在结构性解离框架中的角色，并说明当其在切换过程中暂时接管前台时的表现、触发因子与自助策略，帮助多意识体系统在高监控状态下维持安全。
+synonyms:
+  - 观察者 ANP
+  - Observer ANP Switch
+  - 旁观型 ANP 切换
+  - 监护 ANP 前台
+  - Observer State ANP
+tags:
+  - ops:系统运作
+  - theory:结构性解离
+  - sx:切换
+title: 观察者 ANP 切换（Observer ANP Switch）
+topic: 系统运作
+updated: 2025-11-17
+---
+
+
+# 观察者 ANP 切换（Observer ANP Switch）
+
+**一句话定义**：观察者 ANP 切换指结构性解离框架下，负责监控与记录的表面正常部分（ANP）在切换过程中短暂接管前台，以“旁观者”姿态处理现实输入、防止失控的状态。
+
+!!! info "术语定位"
+    - **理论来源**：基于[结构性解离理论](Structural-Dissociation-Theory.md)与[ANP-EP 模型](Apparently-Normal-Part-Emotional-Part-Model.md)对多 ANP 的描述，结合临床访谈中“观察者态（Observer State）”的记录。[^vanderhart2006]
+    - **性质**：现象级语言，常见于 DID/OSDD/CPTSD 系统中，非 ICD/DSM 正式诊断术语。
+    - **功能**：提供风险评估、外部沟通或“紧急接管”，防止 EP 激活后造成行为失控；也可能在治疗中支持信息整合。
+
+---
+
+## 形成背景与触发情境
+
+| 场景 | 触发机制 | 观察者 ANP 的任务 |
+| --- | --- | --- |
+| **高风险外部事件** | 驾驶、照护儿童、职场演示等需要高度控制的任务突然受到创伤触发 | 迅速接管身体以维持动作流程，允许主要 ANP/EP 在后台处理情绪 |
+| **治疗或创伤加工** | EMDR、深度访谈、感觉运动疗法等引发强烈记忆 | 负责记录对话、与治疗师沟通“过载”信号，并协调暂停 |
+| **系统内部冲突** | 多个成员争执或守门人判断“不宜切换” | 以“中立旁观者”角色暂时压住争夺，确保外部安全 |
+| **记忆或信息传递** | 需要跨成员共享事实、时间线或医疗信息 | 通过日志、可视化或口述把信息带出，减少失忆 |
+
+这些场景常发生在 ANP 长期超负荷、EP 情绪高涨或守门人评估外部风险极高的情况下。[^steele2017]
+
+---
+
+## 与相关概念的区分
+
+| 概念 | 相同点 | 核心差异 |
+| --- | --- | --- |
+| [切换（Switch）](Switch.md) | 都涉及控制权交接 | 观察者 ANP 切换属于“过渡型”切换，重点在监控与稳态，而非长期接管 |
+| [ANP–EP 混溶（ANP–EP Blending）](ANP-EP-Blending.md) | 都发生在 ANP/EP 接近前台时 | 混溶强调功能边界模糊、情绪互渗；观察者 ANP 切换则维持情感距离、优先执行监控任务 |
+| [自动驾驶（Autopilot）](Autopilot.md) | 都可能出现“机器人般”执行 | 自动驾驶缺乏主观旁观体验，而观察者 ANP 明确感知“我在看身体行动” |
+| 守门人/保护者角色 | 都承担安全职责 | 守门人通常是独立成员；观察者 ANP 是 ANP 子类型，以“记录 +执行”结合为主 |
+
+---
+
+## 体验结构：三阶段拆解
+
+1. **预接管**：主要 ANP 感到“要失控”或 EP 强烈冲击，内部对话呼叫观察者 ANP。体感可能是胸口紧、视角后移。
+2. **旁观接管**：观察者 ANP 在前台保持平板语气、机械动作，与外界交流时语速放慢，内部保持“正在记录”念头。多数人描述“像摄影机在操作身体”。
+3. **交接/整合**：当威胁解除或治疗师协助定向后，观察者 ANP 将所见所感转交其他成员，通过日志、语音或内部会议完成收尾。若交接失败，可能转入[ANP–EP 混溶](ANP-EP-Blending.md)或解离性麻木。
+
+---
+
+## 识别信号
+
+- **语言特征**：使用第三人称描述自身（“她正在哭，我在看”）、语调趋于平坦。
+- **身体姿态**：视线固定在远处、动作机械；手指轻敲、写笔记等监控动作频发。[^loewenstein1991]
+- **意识描述**：强调“我只是在记录”“感觉像屏幕”，伴随轻微时间延迟感。
+- **记忆结果**：对事件有客观记忆但缺少情感色彩，呈现“灰色影片”质感。
+
+若观察者 ANP 长时间无法退场，可能出现失眠、情绪钝化或社交疏离，需要额外支持。
+
+---
+
+## 协作与自助策略
+
+### 1. 切换前准备
+
+- **角色协议**：与守门人或主要 ANP 设定“何时呼叫观察者”“谁负责记录”“谁负责收尾”。
+- **外部提示**：准备携带式卡片或 wearable 震动提醒，写明安全计划与紧急联系人，便于观察者 ANP 迅速查阅。
+
+### 2. 切换过程中
+
+- **双通道接地**：一手执行任务，一手维持触觉锚点（手握石头、踏地），确保身体感与现实同步。参见[接地（Grounding）](Grounding.md)。
+- **时间戳记录**：口头或书面标记当前日期、地点，可在后续回顾时帮助其他成员拼接记忆。
+- **外部沟通**：若与治疗师/可信任伙伴同在，直接说明“观察者在前台”以争取缓冲时间。
+
+### 3. 收尾阶段
+
+- **温和交接**：通过深呼吸、热水、舒适物品帮助身体从警戒降级，再邀请主要 ANP 或相关 EP 接手。
+- **总结日志**：记录“为何需要观察者”“看到了什么”“下次需调整之处”，协助系统学习。
+- **解压与补偿**：观察者 ANP 虽不带强烈情绪，但长期高监控仍会疲劳；安排休息或内在感谢仪式，避免其长期卡在前台。[^steele2017]
+
+---
+
+## 治疗与专业合作提示
+
+- **阶段化治疗**：遵循 ISSTD “稳定化 → 创伤加工 → 整合”原则，在第一阶段训练观察者 ANP 的接地与沟通技能，再逐步引导其参与创伤叙事。[^isstd2011]
+- **告知治疗师**：在治疗前说明系统存在“观察者 ANP”，以便治疗师识别语调突变、目光散焦等信号，并在必要时暂停加工、转入定向。
+- **风险评估**：若观察者 ANP 接管时伴随心率飙升、晕眩或近失神，应评估是否需要医学检查或调整药物。
+
+---
+
+## 相关条目
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](Apparently-Normal-Part-Emotional-Part-Model.md)
+- [ANP–EP 混溶（ANP–EP Blending）](ANP-EP-Blending.md)
+- [切换（Switch）](Switch.md)
+- [前台（Front / Fronting）](Front-Fronting.md)
+- [守门人（Gatekeeper）](Gatekeeper.md)
+- [接地（Grounding）](Grounding.md)
+
+---
+
+## 参考资料
+
+[^vanderhart2006]: Van der Hart, O., Nijenhuis, E. R. S., & Steele, K. (2006). *The Haunted Self: Structural Dissociation and the Treatment of Chronic Traumatization*. W. W. Norton & Company.
+[^steele2017]: Steele, K., Boon, S., & van der Hart, O. (2017). *Treating Trauma-Related Dissociation: A Practical, Integrative Approach*. W. W. Norton & Company.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision. *Journal of Trauma & Dissociation*, 12(2), 115–187.
+[^loewenstein1991]: Loewenstein, R. J. (1991). An Office Mental Status Examination for Complex Chronic Dissociative Symptoms and Multiple Personality Disorder. *Psychiatric Clinics of North America*, 14(3), 567–604.


### PR DESCRIPTION
## Summary
- 新增「观察者 ANP 切换」词条，说明术语定位、触发场景、识别信号与协作策略，并补充参考文献
- 在 ANP–EP 模型词条新增指向「ANP–EP 混溶」与「观察者 ANP 切换」的相关条目链接，凸显模型下的具体运作现象
- 更新 ANP–EP 混溶词条的相关条目，加入新的交叉引用，方便读者横向查阅

## Testing
- python3 tools/check_links.py docs/entries/
- python3 tools/check_tags.py docs/entries/


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae331af1c8333b71791fc37f4d3ab)