### PR TITLE
feat: 新增情绪化进食词条并同步诊断与临床导览

### DIFF
--- a/docs/entries/Emotional-Eating.md
+++ b/docs/entries/Emotional-Eating.md
@@ -1,0 +1,183 @@
+---
+comments: true
+description: 情绪化进食是由情绪而非生理饥饿驱动的进食模式，常与压力、抑郁、焦虑及创伤史相关，处于正常应对与进食障碍之间的连续谱。
+synonyms:
+
+- 情绪性进食
+- Emotional Eating
+
+tags:
+
+- guide:诊断与临床
+- dx:进食障碍
+- dx:情绪化进食
+- tx:情绪调节
+- guide:风险管理
+
+title: 情绪化进食(Emotional Eating)
+topic: 诊断与临床
+updated: 2026-04-10
+---
+
+# 情绪化进食(Emotional Eating)
+
+!!! warning "触发警告"
+    内容涉及暴食、自我羞耻、自伤与自杀风险等议题，请根据当前状态选择阅读。
+
+!!! info "免责声明"
+    本词条仅用于心理健康科普，不能替代专业诊断与治疗。
+
+---
+
+## 概述
+
+情绪化进食指个体在负面情绪（如焦虑、抑郁、孤独、愤怒）或正面情绪（如庆祝、奖励）驱动下，而非生理饥饿信号引导下产生的进食行为。其核心特征是：进食承担了情绪调节功能，用于短期缓解痛苦、回避情绪，或延长愉悦体验。
+
+情绪化进食位于正常进食行为与临床进食障碍之间的连续谱上：它可以是偶发应对策略，也可能发展为持续失调模式。ICD-11 与 DSM-5-TR 未将其列为独立诊断，但在 [暴食障碍(Binge Eating Disorder, BED)](Binge-Eating-Disorder.md) 和 [神经性贪食症(Bulimia Nervosa, BN)](Bulimia-Nervosa.md) 中常见并具有临床意义。
+
+---
+
+## 临床表现
+
+### 进食模式特征
+
+- **突发性**：常与情绪波动同步出现，而非渐进性饥饿。
+- **选择性**：偏好高糖、高脂、高热量的“安慰性食物”。
+- **失控感**：进食时“停不下来”，但程度可轻于 BED 的典型暴食发作。
+- **继发情绪**：进食后常出现内疚、羞耻、自我厌恶，形成“情绪—进食—自责”的循环。
+
+### 常见触发因素
+
+- **负性情绪**：焦虑、悲伤、孤独、无聊、愤怒、压力。
+- **正性情绪**：庆祝或奖励性进食（通常痛苦感较轻）。
+- **高压情境**：考试季、工作截止期、人际冲突、纪念日。
+- **生理放大器**：睡眠剥夺、长期节食、昼夜节律紊乱。
+
+### 共病与功能损害
+
+- 体重增加、肥胖与代谢风险升高。
+- 睡眠障碍（含夜间进食相关表现）。
+- 与抑郁、焦虑双向强化。
+- 严重时可伴自伤冲动、替代性成瘾行为（如酒精、尼古丁）。
+
+---
+
+## 机制与背景
+
+### 心理机制：负强化与经验性回避
+
+情绪化进食常由“负强化”维持：进食暂时降低情绪痛苦，行为被反复强化。长期看，个体可能更依赖进食回避情绪，而较少发展认知重评、情绪接纳和人际求助等适应性策略。
+
+### 情绪调节模型
+
+- **情绪粒度不足**：难以精确命名情绪（“只觉得难受”），更容易用进食快速应对。
+- **策略库贫乏**：缺少可替代方法时，进食成为默认策略。
+- **自我效能低**：不相信自己能调节情绪，增加冲动性进食风险。
+
+### 生理机制：压力轴与奖赏系统
+
+- 慢性压力可通过 HPA 轴与皮质醇升高，增强对高热量食物偏好。
+- 高奖赏食物快速激活 [奖赏系统(Reward System)](Reward-System.md)，短期缓解不适。
+- 长期反复后可能出现“奖赏钝化”，需要更强刺激才能获得同等缓解。
+
+### 发展性创伤与依恋
+
+儿童期不良经历（ACEs）、情感忽视与不安全依恋与情绪化进食风险升高相关。部分个体将食物作为“替代性安抚对象”，以应对不稳定的安全感与关系压力。
+
+---
+
+## 流行病学与病程
+
+- 一般人群中情绪化进食报告率差异较大，受工具与定义影响明显。
+- 女性报告率通常高于男性；青春期到成年早期常见加重。
+- 在肥胖人群及 BED 患者中，情绪化进食更常见。
+- 病程可为间歇性（压力期加重）或慢性化（长期反复）。
+- 预后受支持系统、睡眠质量、节食行为与共病管理影响。
+
+---
+
+## 鉴别诊断
+
+- [暴食障碍(Binge Eating Disorder, BED)](Binge-Eating-Disorder.md)：需满足客观大量进食 + 失控感 + 频率/病程标准。
+- [神经性贪食症(Bulimia Nervosa, BN)](Bulimia-Nervosa.md)：关键在于存在规律性代偿行为（催吐、泻药、过度运动等）。
+- [神经性厌食症(Anorexia Nervosa, AN)](Anorexia-Nervosa.md)：核心为显著低体重与强烈增重恐惧。
+- [抑郁障碍](Depressive-Disorders.md) / [焦虑障碍](Anxiety-Disorders.md)：情绪症状可能原发，进食改变可为继发。
+
+---
+
+## 共病与风险管理
+
+### 常见共病
+
+- 肥胖与代谢综合征
+- [抑郁障碍](Depressive-Disorders.md)
+- [焦虑障碍](Anxiety-Disorders.md)
+- [创伤后应激障碍(PTSD)](PTSD.md)
+- [边缘型人格障碍(BPD)](Borderline-Personality-Disorder-BPD.md)
+- [物质使用障碍(SUD)](Substance-Use-Disorders-SUD.md)
+
+### 风险评估重点
+
+- 常规评估自伤/自杀意念，尤其在严重羞耻、绝望和多重共病时。
+- 识别“高危时间窗”（如夜间独处、冲突后、睡眠不足后）。
+- 避免体重羞辱与道德化语言，采用创伤知情、体重中性、合作式目标设定。
+
+### 危机应对示例
+
+- **延迟策略**：先延后 15 分钟，再决定是否进食。
+- **替代行为**：冷水洗脸、握冰块、短时快走、呼叫支持者。
+- **接地技巧**：5-4-3-2-1 感官练习，降低高唤醒状态。
+
+---
+
+## 治疗与支持
+
+### 阶段 1：评估与心理教育
+
+- 区分生理饥饿与情绪饥饿，建立“情绪—冲动—行为”记录。
+- 可使用 DEBQ、TFEQ 等工具辅助评估（由专业人员解释）。
+
+### 阶段 2：情绪调节技能训练
+
+- 正念进食与内感受训练，提高饥饿/饱腹信号识别。
+- 情绪粒度训练，提升情绪命名与分化能力。
+- 认知重评与痛苦耐受训练，可结合 [辩证行为疗法(DBT)](Dialectical-Behavior-Therapy-DBT.md)。
+
+### 阶段 3：进食行为重塑与复发预防
+
+- 建立规律进食节律，减少“限制—反扑”循环。
+- 从过度节食转向更可持续的内部信号导向（如直觉性进食原则）。
+- 对高危情境做预案，并通过“复发后学习日志”替代自我惩罚。
+
+### 多学科协作
+
+慢性或复杂个案建议由心理治疗师、营养师、内科与精神科协作，兼顾情绪调节、营养结构、代谢健康与共病治疗。
+
+---
+
+## 社群与临床语境
+
+- 社群讨论常在“行为改变”与“自我接纳”之间寻找平衡。
+- 创伤知情与体重中性（Weight-Neutral）路径有助于减少羞耻与治疗脱落。
+- 需警惕媒体和减肥产业将情绪化进食简化为“意志力差”，这会加重污名与复发风险。
+
+---
+
+## 相关条目
+
+1. [暴食障碍(Binge Eating Disorder, BED)](Binge-Eating-Disorder.md)
+2. [神经性贪食症(Bulimia Nervosa, BN)](Bulimia-Nervosa.md)
+3. [辩证行为疗法(DBT)](Dialectical-Behavior-Therapy-DBT.md)
+4. [奖赏系统(Reward System)](Reward-System.md)
+5. [进食障碍总览（ED）](Eating-Disorders-ED.md)
+
+---
+
+## 参考与延伸阅读
+
+1. American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders (5th ed., text rev.).*
+2. Frayn, M., & Knäuper, B. (2018). Emotional eating and weight in adults: A review. *Current Psychology, 37*(3), 924–933.
+3. Konttinen, H. (2020). Emotional eating and obesity in adults: The role of depression, sleep and genes. *Proceedings of the Nutrition Society, 79*(3), 283–289.
+4. Leahy, R. L., Tirch, D., & Napolitano, L. A. (2011). *Emotion Regulation in Psychotherapy: A Practitioner's Guide.*
+5. Linardon, J., & Mitchell, S. (2022). A systematic review and meta-analysis of psychological interventions for emotional eating. *Appetite, 168*, 105775.
+6. World Health Organization. (2019). *ICD-11 for Mortality and Morbidity Statistics.*

--- a/docs/guides/Clinical-Diagnosis-Guide.md
+++ b/docs/guides/Clinical-Diagnosis-Guide.md
@@ -292,6 +292,7 @@ search:
     - [神经性厌食症（Anorexia Nervosa, AN）](../entries/Anorexia-Nervosa.md) — :octicons-check-16: 已完成
     - [神经性贪食症（Bulimia Nervosa, BN）](../entries/Bulimia-Nervosa.md) — :octicons-check-16: 已完成
     - [暴食障碍（Binge-Eating Disorder, BED）](../entries/Binge-Eating-Disorder.md) — :octicons-check-16: 已完成
+    - [情绪化进食（Emotional Eating）](../entries/Emotional-Eating.md) — :octicons-check-16: 已完成
     - 回避/限制性食物摄入障碍（ARFID）等 — :octicons-clock-16: 待更新
 
 ### 11) 排泄障碍


### PR DESCRIPTION
### Motivation

- 补全关于“情绪化进食(Emotional Eating)”的科普/临床词条，明确其与暴食障碍/贪食症等的关系并提供可操作的风险管理与干预路径。

### Description

- 新增词条 `docs/entries/Emotional-Eating.md`，包含 Frontmatter（`title/topic/tags/updated`）与概述、临床表现、机制、流行病学、鉴别诊断、共病与风险管理、分阶段治疗与参考文献等结构化内容。 
- 在诊断导览 `docs/guides/Clinical-Diagnosis-Guide.md` 的“10) 喂养与进食障碍”分组中加入 `Emotional-Eating.md` 的相对路径入口以保持 Guide 与词条同步。 
- 所有内部链接使用相对路径并参照现有模板（如对 `Binge-Eating-Disorder.md`、`Bulimia-Nervosa.md`、`Dialectical-Behavior-Therapy-DBT.md`、`Reward-System.md` 的引用）。

### Testing

- 运行 `python3 tools/check_links.py docs/entries/Emotional-Eating.md` 与 `python3 tools/check_tags.py docs/entries/Emotional-Eating.md`，校验通过。 
- 运行 `python3 tools/check_links.py docs/entries/` 与 `python3 tools/check_tags.py docs/entries/`，全库词条检查通过，未发现链接或标签规范问题。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c9f485608333988f30abe5af3043)