### PR TITLE
fix: 更新首页友情链接地址

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -310,7 +310,7 @@ search:
 
 <div align="center" markdown>
 
-:material-link-variant: **友情链接**：[我们一起向前走](https://wiki.51320721.xyz/)  
+:material-link-variant: **友情链接**：[我们一起向前走](https://our.51320721.xyz)  
 :material-github: **开源协作**：本项目在 [GitHub](https://github.com/mps-team-cn/Multiple_personality_system_wiki) 上开源  
 :material-license: **许可协议**：内容遵循 [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.zh-hans)  
 


### PR DESCRIPTION
### Motivation
- 更新首页“友情链接”目标 URL，从旧的 `https://wiki.51320721.xyz/` 指向新的 `https://our.51320721.xyz`，以反映新域名。

### Description
- 修改 `docs/index.md` 中友情链接行，将链接替换为 `https://our.51320721.xyz`，未改动其他文案或页面结构。

### Testing
- 运行了 `python3 tools/check_links.py docs/entries/` 和 `python3 tools/check_tags.py docs/entries/`，两项自动检查均通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9089f3c833396a64e6db78da6d1)