### PR TITLE
[codex] 更新首页友链显示名称

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -310,7 +310,7 @@ search:
 
 <div align="center" markdown>
 
-:material-link-variant: **友情链接**：[我们一起向前走](https://our.51320721.xyz)  
+:material-link-variant: **友情链接**：[暖源社W.S.S(原我们一起向前走)](https://our.51320721.xyz)  
 :material-github: **开源协作**：本项目在 [GitHub](https://github.com/mps-team-cn/Multiple_personality_system_wiki) 上开源  
 :material-license: **许可协议**：内容遵循 [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.zh-hans)  
 


### PR DESCRIPTION
## 变更内容

- 将首页友情链接显示名从“我们一起向前走”更新为“暖源社W.S.S(原我们一起向前走)”。
- 保持原友链地址 `https://our.51320721.xyz` 不变。

## 修复原因

处理 #461。该社区已改名，首页友链区域仍显示旧名称。

## 影响范围

仅影响首页友链展示文本，不改变链接目标或其他页面内容。

## 验证

- `python3 tools/check_links.py docs/index.md`
- `python3 tools/check_links.py docs/entries/`
- `python3 tools/check_tags.py docs/entries/`