### PR TITLE
[codex] perf: 按页面加载量表资源

### DIFF
--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -21,6 +21,7 @@ if (typeof window !== 'undefined') {
 document.addEventListener('DOMContentLoaded', function() {
   // 关键任务：立即执行
   addStructuredData();
+  labelSearchDialog();
 
   // 非关键任务：使用 requestIdleCallback 延迟执行
   scheduleIdleTask(() => {
@@ -120,6 +121,8 @@ function enhanceBackToTop() {
  */
 if (typeof document$ !== 'undefined' && document$.subscribe) {
   document$.subscribe(function() {
+    labelSearchDialog();
+
     // 使用事件委托，避免为每个按钮添加监听器
     const content = document.querySelector('.md-content');
     if (!content) return;
@@ -139,6 +142,17 @@ if (typeof document$ !== 'undefined' && document$.subscribe) {
       }, 2000);
     });
   });
+}
+
+/**
+ * 为 Material 搜索对话框补充可访问名称。
+ */
+function labelSearchDialog() {
+  const dialog = document.querySelector('.md-search[role="dialog"]');
+  if (!dialog) return;
+  if (!dialog.getAttribute('aria-label') && !dialog.getAttribute('aria-labelledby')) {
+    dialog.setAttribute('aria-label', '站内搜索');
+  }
 }
 
 /**

--- a/docs/entries/Dissociative-Experiences-Scale-DES-II.md
+++ b/docs/entries/Dissociative-Experiences-Scale-DES-II.md
@@ -4,6 +4,14 @@ hide:
 
 - toc
 
+extra_css:
+
+- assets/des2.css
+
+extra_javascript:
+
+- assets/des2.js
+
 search:
   boost: 1.5
 synonyms:

--- a/docs/entries/Generalized-Anxiety-Disorder-7-GAD-7.md
+++ b/docs/entries/Generalized-Anxiety-Disorder-7-GAD-7.md
@@ -25,6 +25,11 @@ hide:
 
     - toc
 
+extra_css:
+    - assets/brief-scales.css
+extra_javascript:
+    - assets/brief-scales.js
+
 comments: true
 ---
 

--- a/docs/entries/Multidimensional-Inventory-of-Dissociation-MID-60.md
+++ b/docs/entries/Multidimensional-Inventory-of-Dissociation-MID-60.md
@@ -3,6 +3,14 @@ hide:
 
 - toc
 
+extra_css:
+
+- assets/mid60.css
+
+extra_javascript:
+
+- assets/mid60.js
+
 search:
   boost: 1.5
 synonyms:

--- a/docs/entries/Patient-Health-Questionnaire-9-PHQ-9.md
+++ b/docs/entries/Patient-Health-Questionnaire-9-PHQ-9.md
@@ -25,6 +25,11 @@ hide:
 
     - toc
 
+extra_css:
+    - assets/brief-scales.css
+extra_javascript:
+    - assets/brief-scales.js
+
 comments: true
 ---
 

--- a/docs/entries/Self-Rating-Anxiety-Scale-SAS.md
+++ b/docs/entries/Self-Rating-Anxiety-Scale-SAS.md
@@ -22,6 +22,11 @@ hide:
 
     - toc
 
+extra_css:
+    - assets/sas.css
+extra_javascript:
+    - assets/sas.js
+
 comments: true
 ---
 

--- a/docs/entries/Self-Rating-Depression-Scale-SDS.md
+++ b/docs/entries/Self-Rating-Depression-Scale-SDS.md
@@ -22,6 +22,11 @@ hide:
 
     - toc
 
+extra_css:
+    - assets/sds.css
+extra_javascript:
+    - assets/sds.js
+
 comments: true
 ---
 

--- a/docs/entries/Somatoform-Dissociation-Questionnaire-SDQ-20.md
+++ b/docs/entries/Somatoform-Dissociation-Questionnaire-SDQ-20.md
@@ -4,6 +4,14 @@ hide:
 
 - toc
 
+extra_css:
+
+- assets/sdq20.css
+
+extra_javascript:
+
+- assets/sdq20.js
+
 search:
   boost: 1.5
 synonyms:

--- a/docs/entries/Symptom-Checklist-90-SCL-90.md
+++ b/docs/entries/Symptom-Checklist-90-SCL-90.md
@@ -24,6 +24,11 @@ hide:
 
     - toc
 
+extra_css:
+    - assets/scl90.css
+extra_javascript:
+    - assets/scl90.js
+
 comments: true
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,26 +157,12 @@ extra:
 # 额外样式和脚本
 extra_css:
   - assets/extra-material.css # Material 主题专用增强样式
-  - assets/brief-scales.css
-  - assets/des2.css
-  - assets/mid60.css
-  - assets/scl90.css
-  - assets/sdq20.css
-  - assets/sds.css
-  - assets/sas.css
 
 extra_javascript:
   - assets/extra.js
   - assets/gtm-loader.js  # GTM/GA 延迟加载
   - assets/giscus-loader.js  # Giscus 评论加载器
   - assets/search-phrase-default.js # 搜索短语自动加引号
-  - assets/brief-scales.js
-  - assets/des2.js
-  - assets/mid60.js
-  - assets/scl90.js
-  - assets/sdq20.js
-  - assets/sds.js
-  - assets/sas.js
 
 
 # Markdown 扩展

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -42,6 +42,19 @@
   <meta name="robots" content="{{ page.meta.robots }}">
   {% endif %}
 
+  {# 页面级资源：由 Frontmatter 声明，避免量表 CSS/JS 全站加载。 #}
+  {% if page and page.meta and page.meta.extra_css %}
+    {% for path in page.meta.extra_css %}
+  <link rel="stylesheet" href="{{ path | url }}">
+    {% endfor %}
+  {% endif %}
+
+  {% if page and page.meta and page.meta.extra_javascript %}
+    {% for path in page.meta.extra_javascript %}
+  <script defer src="{{ path | url }}"></script>
+    {% endfor %}
+  {% endif %}
+
   {# 将 GA Measurement ID 注入到全局，供延迟加载脚本使用 #}
   {% if config.extra and config.extra.analytics and config.extra.analytics.property %}
   <script>


### PR DESCRIPTION
## 变更内容

- 将量表相关 CSS/JS 从 `mkdocs.yml` 的全站资源中移除。
- 在 8 个交互式量表词条 Frontmatter 中声明各自需要的 `extra_css` / `extra_javascript`。
- 在 `overrides/main.html` 中按页面 Frontmatter 输出页面级资源，并补充模板注释说明用途。
- 为 Material 搜索对话框补充 `aria-label`，修复 PageSpeed 报告中的 `aria-dialog-name` 无障碍问题。

## 原因

PageSpeed 报告显示移动端性能主要受 LCP 和资源加载影响。首页原本会全站加载 DES-II、MID-60、SCL-90、SDQ-20、SDS、SAS、PHQ/GAD 等量表资源，但这些资源只在对应量表页使用。改为页面级加载后，首页不再加载约 164 KiB 未压缩的量表 CSS/JS。

## 验证

- `python3 tools/check_links.py docs/entries/`
- `python3 tools/check_tags.py docs/entries/`
- `python3 tools/check_frontmatter.py --path docs/entries`
- `venv/bin/mkdocs build` 通过
- `venv/bin/mkdocs build --strict` 仍被既有 warning 拦下，warning 指向已有 changelog/锚点问题，和本次改动无关
- 检查生成的 `site/index.html`，确认不再包含量表资源；检查 DES-II、SAS、GAD-7 等量表页，确认仍按需包含对应 CSS/JS

## 备注

线上 `robots.txt` 的 PageSpeed 报错来自 Cloudflare 自动插入的 `Content-Signal: search=yes,ai-train=no`，仓库内 `docs/robots.txt` 没有该行，需在 Cloudflare 侧处理。