### PR TITLE
[codex] 新增成人依恋词条

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -175,6 +175,7 @@ comments: true
 | [<abbr title="Apparently Normal Part / Emotional Part">ANP / EP</abbr> 模型](entries/Apparently-Normal-Part-Emotional-Part-Model.md) | 将人格分为"表面正常部分"（<abbr title="Apparently Normal Part">ANP</abbr>）与"情绪部分"（<abbr title="Emotional Part">EP</abbr>），阐释创伤反应 | 临床 | 属于结构性解离理论核心概念 |
 | [埃蒙加德分类](entries/Emmengard-Classification.md) | 社群提出的系统来源分类，如创造型、自发型、混合型等 | 社群 | 与 Tulpa、系魂等实践讨论关联密切 |
 | [依恋理论](entries/Attachment-Theory.md) | 研究早期照料关系对安全感与情绪调节的影响 | 临床 | 用于分析系统内部信任与合作 |
+| [成人依恋](entries/Adult-Attachment.md) | 解释成年关系中的依恋焦虑、依恋回避与安全/不安全关系模式 | 理论 | 用于理解关系触发、治疗联盟与系统内部安全感 |
 | [自我决定理论（<abbr title="Self-Determination Theory">SDT</abbr>）](entries/Self-Determination-Theory.md) | 强调自主性、胜任感、连结感三个基本动机需求 | 跨域 | 可指导目标设定与支持策略 |
 | [社会认知理论](entries/Social-Cognitive-Theory.md) | 关注观察学习与自我效能在行为形成中的作用 | 跨域 | 解释成员间的榜样与反馈机制 |
 | [动机理论](entries/Motivation-Theories.md) | 汇整需要层次、强化、期待等经典动机模型 | 跨域 | 帮助设计内部激励与任务分配 |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -322,6 +322,7 @@
         * [习得性无助(Learned Helplessness)](entries/Learned-Helplessness.md)
         * [人本主义心理学（Humanistic Psychology）](entries/Humanistic-Psychology.md)
         * [人格结构理论（Personality Structure Theory, Freud）](entries/Personality-Structure-Theory.md)
+        * [成人依恋（Adult Attachment）](entries/Adult-Attachment.md)
         * [依恋理论（Attachment Theory）](entries/Attachment-Theory.md)
         * [动机理论（Motivation Theories）](entries/Motivation-Theories.md)
         * [多意识体系统中的创伤功能分化（Functional Dissociation of Trauma in Plural Systems）](entries/Functional-Dissociation-of-Trauma-in-Plural-Systems.md)

--- a/docs/entries/Adult-Attachment.md
+++ b/docs/entries/Adult-Attachment.md
@@ -1,0 +1,164 @@
+---
+comments: true
+description: 成人依恋（Adult Attachment）解释亲密关系中的安全型、焦虑型、回避型与恐惧-回避型依恋模式，涵盖内部工作模型、依恋焦虑、依恋回避及其在创伤、解离和系统协作中的意义。
+search:
+  boost: 1.5
+synonyms:
+
+- 成人依恋
+- 成人依附
+- 成人依恋类型
+- 成人依恋风格
+- 成人依恋模式
+- 成人依恋理论
+- 依恋风格
+- 依恋类型
+- adult attachment
+- adult attachment styles
+- attachment styles in adults
+- secure attachment
+- anxious attachment
+- avoidant attachment
+- fearful avoidant attachment
+
+tags:
+
+- theory:依恋理论
+- theory:成人依恋
+- theory:关系模式
+- tx:创伤知情
+- sx:情绪调节
+
+title: 成人依恋（Adult Attachment）
+topic: 理论与分类
+updated: 2026-05-12
+---
+
+# 成人依恋（Adult Attachment）
+
+## 概述
+
+成人依恋（Adult Attachment）是[依恋理论](Attachment-Theory.md)在成年亲密关系、友谊、家庭关系与治疗关系中的延伸。它关注一个人在关系压力下如何寻求安全、表达需要、保持距离、处理分离，以及如何理解“我是否值得被爱”“他人是否可靠”。
+
+!!! tip "快速答案"
+    **成人依恋**不是精神障碍诊断，而是描述亲密关系模式的心理学框架。常见模型会从 **依恋焦虑** 与 **依恋回避** 两个维度理解个体差异，并由此概括出安全型、焦虑-沉溺型、疏离-回避型、恐惧-回避型等模式。
+
+## 核心模型
+
+### 依恋焦虑与依恋回避
+
+当代成人依恋研究常把依恋差异理解为两个连续维度：
+
+- **依恋焦虑**：担心被拒绝、被抛弃、关系不稳定，容易反复确认对方是否仍在乎自己。
+- **依恋回避**：对亲密、依赖和暴露脆弱感到不适，倾向于保持距离、压抑需要或强调自给自足。
+
+低焦虑、低回避通常接近安全型依恋；高焦虑或高回避则可能对应不同形式的不安全依恋。
+
+### 四种常见依恋模式
+
+| 模式 | 自我感受 | 他人预期 | 常见表现 |
+|------|----------|----------|----------|
+| **安全型** | 我基本值得被爱 | 他人大体可靠 | 能在亲密与独立之间切换，冲突时较能沟通和修复 |
+| **焦虑-沉溺型** | 我可能不够好 | 他人可能离开我 | 渴望亲密，容易过度确认、害怕冷淡、对延迟回应敏感 |
+| **疏离-回避型** | 我可以靠自己 | 他人不太可靠 | 强调独立，减少表达需要，关系变近时可能拉开距离 |
+| **恐惧-回避型** | 我不安全或不值得 | 他人也危险或不可依靠 | 同时渴望亲密又害怕亲密，可能在靠近与撤离之间摆荡 |
+
+这些模式是理解关系策略的简化地图，不是人格判决。一个人可以在伴侣、朋友、家人、治疗师或系统内部成员之间呈现不同模式。
+
+## 内部工作模型
+
+依恋理论中的 **内部工作模型** 指个体在关系经验中形成的基本预期，例如：
+
+- **关于自我**：我是否值得被照顾、被理解、被保护？
+- **关于他人**：重要他人是否会回应、是否会伤害、是否会离开？
+- **关于关系**：亲密是安全的、窒息的，还是随时会崩塌的？
+
+在创伤环境中，内部工作模型可能变得高度警觉：亲密被理解为危险，分离被理解为抛弃，需求表达被理解为会招致惩罚。这些预期会影响[情绪调节](Emotion-Regulation.md)、[防御机制](Defense-Mechanisms.md)、冲突处理与治疗关系。
+
+## 在多意识体与解离语境中的意义
+
+多意识体系统不一定共享单一依恋模式。不同成员可能根据年龄感、创伤记忆、角色功能和前台经验形成不同关系策略：
+
+- **儿童成员或创伤持有者**：可能对分离、冷淡、沉默高度敏感，需要可预测的安抚和确认。
+- **保护者或执行者**：可能把依赖理解为风险，优先隔离情绪、控制接触或减少暴露。
+- **照护者成员**：可能承担内部安全基地功能，但也可能过度负责、忽视自身需求。
+- **前台成员**：可能需要在外部关系中协调不同成员的亲密需求与边界。
+
+这类差异不意味着系统“矛盾”或“失败”，而是不同部分用不同策略维持安全。实践重点是识别策略背后的需求，而不是强行要求所有成员采用同一种关系风格。
+
+## 实践应用
+
+### 自我观察问题
+
+- 当重要他人没有回复时，我最先出现的是担心、愤怒、麻木，还是想断开关系？
+- 我更害怕“被抛弃”，还是更害怕“被吞没、被控制、失去自主”？
+- 我表达需要后，脑中最常出现的预期是什么？
+- 系统内部是否有成员特别害怕分离，或特别抗拒依赖？
+
+### 系统协作建议
+
+- **把标签换成需求语言**：少说“你就是焦虑型”，多说“这里是不是需要更稳定的回应？”
+- **建立可预测联系**：用固定报平安、内部留言、日程提示等方式降低不确定性。
+- **尊重回避的保护功能**：回避不等于不在乎，可能是在避免过载或再受伤。
+- **用接地降低触发强度**：关系冲突激活旧有恐惧时，先使用[接地技巧](Grounding.md)稳定，再讨论关系议题。
+- **治疗中慢慢测试信任**：创伤知情治疗强调稳定、边界和节奏，不宜强迫快速暴露依恋创伤。
+
+## 常见误区
+
+!!! warning "不要把依恋类型当成固定身份"
+    依恋模式不是诊断，也不是给伴侣、成员或自己定性的标签。它更适合用来理解“在压力下我如何保护自己”，以及“怎样的关系条件能让我更安全”。
+
+- **误区 1：所有关系问题都来自童年**  
+    早期照护很重要，但成年经历、伴侣互动、社会压力、神经多样性、创伤事件和治疗经验都会影响依恋模式。
+
+- **误区 2：安全型就不会有关系困难**  
+    安全型也会冲突、失望和分离，只是通常更能在压力中沟通、修复和维持边界。
+
+- **误区 3：焦虑型和回避型一定不能相处**  
+    焦虑-回避循环很常见，但通过清晰沟通、节奏调整、治疗支持和稳定回应，关系模式可以改变。
+
+- **误区 4：恐惧-回避型等同于“混乱人格”**  
+    恐惧-回避更多描述亲密与危险感交织的关系策略，常与创伤史相关，不应被污名化。
+
+## 常见问题（FAQ）
+
+??? question "成人依恋类型有哪些？"
+    常见说法包括安全型、焦虑-沉溺型、疏离-回避型、恐惧-回避型。研究上也常用依恋焦虑与依恋回避两个维度来描述，而不是只把人分成固定类别。
+
+??? question "焦虑型依恋和回避型依恋有什么区别？"
+    焦虑型依恋更常围绕“会不会被抛弃”而紧张，回避型依恋更常围绕“亲密会不会让我失去控制或受伤”而后退。两者都可能是保护策略，只是方向不同。
+
+??? question "成人依恋可以改变吗？"
+    可以。依恋模式具有相对稳定性，但不是不可改变的人格本质。稳定关系、治疗联盟、创伤处理、边界练习和反复的安全经验，都可能让个体逐渐发展出更安全的关系策略。
+
+??? question "成人依恋和 DID/OSDD 有什么关系？"
+    DID/OSDD 常与发展性创伤、照护不稳定和解离性应对有关，但成人依恋本身不是 DID/OSDD 的诊断标准。它更适合用于理解成员之间、治疗关系中或外部亲密关系里的安全感与触发模式。
+
+## 与相关概念的区别
+
+| 概念 | 关注重点 | 与成人依恋的关系 |
+|------|----------|------------------|
+| [依恋理论](Attachment-Theory.md) | 依恋系统的总体理论，从儿童照护关系到终身发展 | 成人依恋是其在成年关系中的应用 |
+| [分离焦虑障碍](Separation-Anxiety-Disorder.md) | 对依附对象分离的过度恐惧，达到诊断层面的痛苦和功能损害 | 可能与依恋焦虑相关，但不能等同 |
+| [边缘性人格障碍](Borderline-Personality-Disorder-BPD.md) | 情绪、人际、自我形象与冲动控制的广泛不稳定 | 可伴随不安全依恋，但成人依恋不是人格障碍诊断 |
+| [移情与反移情](Transference-Countertransference.md) | 治疗关系中的旧有关系模板被激活 | 依恋模式会影响移情、治疗联盟与信任建立 |
+
+## 相关条目
+
+- [依恋理论（Attachment Theory）](Attachment-Theory.md)
+- [创伤（Trauma）](Trauma.md)
+- [复杂性创伤后应激障碍（CPTSD）](CPTSD.md)
+- [情绪调节（Emotion Regulation）](Emotion-Regulation.md)
+- [移情与反移情（Transference and Countertransference）](Transference-Countertransference.md)
+- [边缘性人格障碍（BPD）](Borderline-Personality-Disorder-BPD.md)
+- [分离焦虑障碍（Separation Anxiety Disorder）](Separation-Anxiety-Disorder.md)
+- [内部沟通（Internal Communication）](Internal-Communication.md)
+
+## 参考与延伸阅读
+
+1. Fraley, R. C. (2010). [A Brief Overview of Adult Attachment Theory and Research](https://labs.psychology.illinois.edu/~rcfraley/attachment). University of Illinois.
+2. Hazan, C., & Shaver, P. R. (1987). Romantic love conceptualized as an attachment process. *Journal of Personality and Social Psychology*, 52(3), 511-524. https://doi.org/10.1037/0022-3514.52.3.511
+3. Bartholomew, K., & Horowitz, L. M. (1991). [Attachment styles among young adults: A test of a four-category model](https://pubmed.ncbi.nlm.nih.gov/1920064/). *Journal of Personality and Social Psychology*, 61(2), 226-244. https://doi.org/10.1037/0022-3514.61.2.226
+4. Brennan, K. A., Clark, C. L., & Shaver, P. R. (1998). Self-report measurement of adult attachment. In J. A. Simpson & W. S. Rholes (Eds.), *Attachment Theory and Close Relationships* (pp. 46-76). Guilford Press.
+5. Mikulincer, M., & Shaver, P. R. (2016). *Attachment in Adulthood: Structure, Dynamics, and Change* (2nd ed.). Guilford Press.
+6. Wikipedia contributors. [Attachment in adults](https://en.wikipedia.org/wiki/Attachment_in_adults). Wikipedia. 

--- a/docs/entries/Attachment-Theory.md
+++ b/docs/entries/Attachment-Theory.md
@@ -31,6 +31,8 @@ updated: 2026-03-27
 
 自 20 世纪中叶起，依恋理论从精神分析的母婴关系研究扩展到发展心理学、神经科学与跨文化研究。成人依恋理论说明早期经验如何影响亲密关系与组织行为；神经影像研究则揭示依恋安全性与情绪调节网络的关联。
 
+更具体的成年关系模式、依恋焦虑/回避维度与四分类模型，见[成人依恋（Adult Attachment）](Adult-Attachment.md)。
+
 ## 在多意识体与解离语境中的意义
 
 复杂创伤往往伴随不安全依恋，导致[解离](Dissociation.md)与身份分裂。系统成员可能分别承载不同的依恋需求，如保护者内化照顾者角色、儿童部分寻求安慰。识别依恋模式有助于制定内部支持策略，并与治疗师建立更稳定的治疗联盟。
@@ -43,6 +45,7 @@ updated: 2026-03-27
 
 ## 相关条目
 
+- [成人依恋（Adult Attachment）](Adult-Attachment.md)
 - [人本主义心理学（Humanistic Psychology）](Humanistic-Psychology.md)
 - [自我效能感（Self-Efficacy）](Self-Efficacy.md)
 - [动机理论（Motivation Theories）](Motivation-Theories.md)

--- a/docs/guides/Theory-Classification-Guide.md
+++ b/docs/guides/Theory-Classification-Guide.md
@@ -84,6 +84,7 @@ search:
 > 关注关系模式、依恋与心理映射的社会层面。
 
 - 🧸 [依恋理论](../entries/Attachment-Theory.md)：依恋类型的形成与影响。
+- 🔗 [成人依恋（Adult Attachment）](../entries/Adult-Attachment.md)：解释成年亲密关系中的依恋焦虑、依恋回避与四种常见关系模式。
 - 🪢 [社会认知理论](../entries/Social-Cognitive-Theory.md)：观察学习与环境交互。
 - 💬 [移情与反移情](../entries/Transference-Countertransference.md)：治疗情境中的情感投射与反馈。
 - 🎭 [投射（心理学）](../entries/Projection-Psychology.md)：防御性归因机制的解释。

--- a/docs/guides/Theory-Classification-index.md
+++ b/docs/guides/Theory-Classification-index.md
@@ -19,6 +19,7 @@ hide:
 
 ## 词条一览
 
+- [成人依恋（Adult Attachment）](../entries/Adult-Attachment.md) — *2026-05-12*
 - [依恋理论（Attachment Theory）](../entries/Attachment-Theory.md) — *2026-03-27*
 - [注意与觉察（Attention & Awareness）](../entries/Attention-Awareness.md) — *2026-03-27*
 - [行为主义心理学（Behaviorism）](../entries/Behaviorism.md) — *2026-03-27*


### PR DESCRIPTION
## 变更内容

- 新增 docs/entries/Adult-Attachment.md，覆盖成人依恋、依恋焦虑/回避、四分类模型、系统语境应用、FAQ 与参考资料。
- 在依恋理论词条中补充成人依恋入口。
- 同步理论与分类导览、理论索引、SUMMARY 导航与术语表。

## 影响

补充成人依恋相关搜索入口，覆盖成人依恋类型、依恋风格、焦虑型依恋、回避型依恋等查询需求，并把内容接入现有创伤、解离与系统协作知识链路。

## 验证

- python3 tools/check_links.py docs/entries/ 通过
- python3 tools/check_tags.py docs/entries/ 通过
- python3 tools/check_links.py docs/guides/Theory-Classification-Guide.md 通过
- python3 tools/check_links.py docs/guides/Theory-Classification-index.md 通过
- python3 tools/check_links.py docs/SUMMARY.md 通过
- python3 tools/check_links.py docs/Glossary.md 通过

未继续运行 uv 构建；此前 mkdocs build --strict 在既有仓库 warning 上失败，非本次新增词条导致。