### PR TITLE
[codex] 修复工具脚本质量问题

### DIFF
--- a/docs/dev/Tools-Index.md
+++ b/docs/dev/Tools-Index.md
@@ -56,7 +56,7 @@ bash tools/run_local_updates.sh --help
 | **check_frontmatter.py** | 验证词条 Frontmatter 必需字段 | PR | [查看详情](#frontmatter-检查工具) |
 | **update_git_timestamps.py** | 根据 Git 历史自动更新 `updated` 字段 | 合并后 | [查看详情](#git-时间戳更新工具) |
 | **build_partitions_cn.py** | 生成七大主题分区索引页 | 构建时 | [查看详情](#主题分区索引生成) |
-| **mkdocs_hooks.py** | 构建期清理搜索索引、注入最近更新并裁剪 sitemap 中的辅助页 | 构建时 | [MkDocs 配置说明](../dev/MkDocs-Configuration.md) |
+| **mkdocs_hooks.py** | 构建期清理搜索索引、注入最近更新并裁剪 sitemap 中的辅助页,复用 Frontmatter 解析缓存 | 构建时 | [MkDocs 配置说明](../dev/MkDocs-Configuration.md) |
 
 👉 **详细配置和规则说明**:[核心工具详解](Tools-Core.md)
 
@@ -71,8 +71,8 @@ bash tools/run_local_updates.sh --help
 | **check_descriptions.py** | 统计词条 description 字段覆盖率 | 🔍 SEO 审计时 |
 | **add_descriptions.py** | 批量为核心词条添加 SEO 描述 | 📝 内容优化时 |
 | **generate_seo_urls.py** | 生成高权重 URL 列表用于搜索引擎提交 | 📊 SEO 策略规划时 |
-| **mkdocs_hooks.py** | 构建后移除 `SUMMARY`、`includes`、`assets` 等辅助页的 sitemap 暴露，并为指定页面注入 `noindex` | 🧩 站点索引治理时 |
-| **submit_to_google_indexing.py** | 使用 Google Indexing API 批量提交 URL | 🚀 新内容发布时 |
+| **mkdocs_hooks.py** | 构建后移除 `SUMMARY`、`includes`、`assets` 等辅助页的 sitemap 暴露，并为指定页面注入 `noindex`，同时复用 Frontmatter 解析缓存 | 🧩 站点索引治理时 |
+| **submit_to_google_indexing.py** | 使用 Google Indexing API 批量提交 URL,支持从任意工作目录加载同目录 URL 生成器 | 🚀 新内容发布时 |
 | **submit_to_indexnow.py** | 使用 IndexNow 协议推送 URL 到 Bing/Yandex 等 | 🚀 内容更新时(已集成 CI) |
 
 ### 搜索优化(jieba 词典管理)
@@ -98,7 +98,7 @@ bash tools/run_local_updates.sh --help
 
 | 工具 | 功能 | 使用频率 |
 |------|------|---------|
-| **gen_changelog_by_tags.py** | 按 Git 标签生成结构化 changelog | 📅 发布前 |
+| **gen_changelog_by_tags.py** | 按 Git 标签生成结构化 changelog,通过参数列表调用 Git 命令 | 📅 发布前 |
 
 ### 文档导出
 

--- a/tools/gen_changelog_by_tags.py
+++ b/tools/gen_changelog_by_tags.py
@@ -21,7 +21,7 @@ import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple, Dict, Optional
+from typing import Dict, List, Optional, Sequence, Tuple
 
 # Conventional Commits 分组与中文标题
 GROUPS = [
@@ -42,19 +42,18 @@ ENCODING = "utf-8"
 DEFAULT_OUTPUT = "CHANGELOG.md"
 LATEST_TO_HEAD_OUTPUT = "change.log"
 
-def sh(cmd: str) -> str:
-    """Run shell command and return stdout (stripped)."""
-    # 在 Windows 下使用 shell=True 以执行 git 命令
-    return subprocess.check_output(cmd, shell=True, text=True, encoding=ENCODING).strip()
+def sh(cmd: Sequence[str]) -> str:
+    """运行命令并返回去除首尾空白的 stdout。"""
+    return subprocess.check_output(cmd, text=True, encoding=ENCODING).strip()
 
-def try_sh(cmd: str) -> Optional[str]:
+def try_sh(cmd: Sequence[str]) -> Optional[str]:
     try:
         return sh(cmd)
     except subprocess.CalledProcessError:
         return None
 
 def get_repo_root() -> Path:
-    out = sh("git rev-parse --show-toplevel")
+    out = sh(["git", "rev-parse", "--show-toplevel"])
     return Path(out)
 
 def get_repo_slug() -> Optional[str]:
@@ -65,7 +64,7 @@ def get_repo_slug() -> Optional[str]:
       - git@github.com:owner/repo.git
       - https://github.com/owner/repo
     """
-    url = try_sh("git config --get remote.origin.url")
+    url = try_sh(["git", "config", "--get", "remote.origin.url"])
     if not url:
         return None
     url = url.strip()
@@ -79,7 +78,7 @@ def get_repo_slug() -> Optional[str]:
     return None
 
 def get_all_tags_sorted() -> List[str]:
-    out = try_sh("git tag --sort=creatordate")
+    out = try_sh(["git", "tag", "--sort=creatordate"])
     if not out:
         return []
     tags = [t for t in out.splitlines() if t.strip()]
@@ -89,7 +88,7 @@ def get_tag_date(tag: str) -> str:
     """
     返回标签对应提交的日期（YYYY-MM-DD）
     """
-    out = sh(f'git log -1 --format=%ad --date=format:%Y-%m-%d {tag}')
+    out = sh(["git", "log", "-1", "--format=%ad", "--date=format:%Y-%m-%d", tag])
     return out or datetime.now().strftime("%Y-%m-%d")
 
 def get_commits_in_range(rng: str) -> List[Tuple[str, str]]:
@@ -97,7 +96,7 @@ def get_commits_in_range(rng: str) -> List[Tuple[str, str]]:
     返回 (hash, subject) 列表
     rng 例子：  v1.2.0..v1.2.3  或  v1.2.3
     """
-    out = try_sh(f'git log {rng} --pretty=format:"%H|%s"')
+    out = try_sh(["git", "log", rng, "--pretty=format:%H|%s"])
     if not out:
         return []
     commits = []

--- a/tools/mkdocs_hooks.py
+++ b/tools/mkdocs_hooks.py
@@ -39,38 +39,24 @@ def _strip_zero_width(value: str) -> str:
     return value.replace(ZERO_WIDTH_SPACE, "")
 
 
-def _extract_frontmatter_synonyms(file_path: Path) -> list[str]:
-    """从 Markdown 文件的 Frontmatter 中提取 synonyms 字段。
+def _extract_frontmatter_synonyms(frontmatter: Dict[str, Any]) -> list[str]:
+    """从 Frontmatter 中提取 synonyms 字段。
 
     支持两种格式：
     1. 列表格式: synonyms: [syn1, syn2, syn3]
     2. 字符串格式: synonyms: syn1, syn2, syn3
     """
-    if not file_path.exists():
-        return []
+    synonyms = frontmatter.get("synonyms", [])
 
-    content = file_path.read_text(encoding="utf-8")
+    # 处理列表格式
+    if isinstance(synonyms, list):
+        return [str(s).strip() for s in synonyms if s]
 
-    # 匹配 Frontmatter (以 --- 包裹的 YAML)
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
-    if not match:
-        return []
+    # 处理字符串格式（逗号分隔）
+    if isinstance(synonyms, str):
+        return [s.strip() for s in synonyms.split(',') if s.strip()]
 
-    try:
-        frontmatter = yaml.safe_load(match.group(1))
-        synonyms = frontmatter.get("synonyms", [])
-
-        # 处理列表格式
-        if isinstance(synonyms, list):
-            return [str(s).strip() for s in synonyms if s]
-
-        # 处理字符串格式（逗号分隔）
-        if isinstance(synonyms, str):
-            return [s.strip() for s in synonyms.split(',') if s.strip()]
-
-        return []
-    except Exception:
-        return []
+    return []
 
 
 def _extract_frontmatter(file_path: Path) -> Dict[str, Any]:
@@ -87,6 +73,17 @@ def _extract_frontmatter(file_path: Path) -> Dict[str, Any]:
         return yaml.safe_load(match.group(1)) or {}
     except Exception:
         return {}
+
+
+def _get_frontmatter(file_path: Path, cache: Dict[Path, Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """读取 Frontmatter，并在提供 cache 时复用解析结果。"""
+    if cache is None:
+        return _extract_frontmatter(file_path)
+
+    cache_key = file_path.resolve()
+    if cache_key not in cache:
+        cache[cache_key] = _extract_frontmatter(file_path)
+    return cache[cache_key]
 
 
 def _normalize_site_url(site_url: str) -> str:
@@ -118,7 +115,11 @@ def _frontmatter_has_noindex(frontmatter: Dict[str, Any]) -> bool:
     return "noindex" in robots.lower()
 
 
-def _collect_non_indexable_urls(docs_dir: Path, site_url: str) -> set[str]:
+def _collect_non_indexable_urls(
+    docs_dir: Path,
+    site_url: str,
+    frontmatter_cache: Dict[Path, Dict[str, Any]] | None = None,
+) -> set[str]:
     """收集应从 sitemap 中移除的 URL。"""
     urls: set[str] = {
         _source_uri_to_site_url(src_uri, site_url)
@@ -126,7 +127,7 @@ def _collect_non_indexable_urls(docs_dir: Path, site_url: str) -> set[str]:
     }
 
     for md_file in docs_dir.rglob("*.md"):
-        frontmatter = _extract_frontmatter(md_file)
+        frontmatter = _get_frontmatter(md_file, frontmatter_cache)
         if not _frontmatter_has_noindex(frontmatter):
             continue
         src_uri = md_file.relative_to(docs_dir).as_posix()
@@ -135,13 +136,18 @@ def _collect_non_indexable_urls(docs_dir: Path, site_url: str) -> set[str]:
     return urls
 
 
-def _prune_sitemap(site_dir: Path, docs_dir: Path, site_url: str) -> None:
+def _prune_sitemap(
+    site_dir: Path,
+    docs_dir: Path,
+    site_url: str,
+    frontmatter_cache: Dict[Path, Dict[str, Any]] | None = None,
+) -> None:
     """移除不应提交给搜索引擎的辅助页面 URL。"""
     sitemap_path = site_dir / "sitemap.xml"
     if not sitemap_path.exists():
         return
 
-    excluded_urls = _collect_non_indexable_urls(docs_dir, site_url)
+    excluded_urls = _collect_non_indexable_urls(docs_dir, site_url, frontmatter_cache)
     if not excluded_urls:
         return
 
@@ -275,6 +281,7 @@ def on_post_build(config: Dict[str, Any]) -> None:
 
     data = json.loads(search_index.read_text(encoding="utf-8"))
     changed = False
+    frontmatter_cache: Dict[Path, Dict[str, Any]] = {}
 
     for doc in data.get("docs", []):
         # 1. 清理零宽空格
@@ -300,7 +307,8 @@ def on_post_build(config: Dict[str, Any]) -> None:
                 file_path = file_path.with_suffix(".md")
 
             # 提取 synonyms
-            synonyms = _extract_frontmatter_synonyms(file_path)
+            frontmatter = _get_frontmatter(file_path, frontmatter_cache)
+            synonyms = _extract_frontmatter_synonyms(frontmatter)
             if synonyms:
                 # 将 synonyms 添加到搜索文本末尾(作为隐藏关键词)
                 current_text = doc.get("text", "")
@@ -316,7 +324,7 @@ def on_post_build(config: Dict[str, Any]) -> None:
 
     site_url = str(config.get("site_url", "")).strip()
     if site_url:
-        _prune_sitemap(site_dir, docs_dir, site_url)
+        _prune_sitemap(site_dir, docs_dir, site_url, frontmatter_cache)
 
 
 # ===== 最近发布版本：从 changelog.md 解析并渲染到首页 =====

--- a/tools/submit_to_google_indexing.py
+++ b/tools/submit_to_google_indexing.py
@@ -42,6 +42,11 @@ from pathlib import Path
 from typing import List, Dict, Tuple, Optional
 from datetime import datetime
 
+# 添加 tools 目录到路径,确保从任意工作目录或以模块方式运行时都能导入同目录脚本
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
 try:
     from google.oauth2 import service_account
     from googleapiclient.discovery import build


### PR DESCRIPTION
## 变更内容

- 将 `gen_changelog_by_tags.py` 的 Git 命令调用从 `shell=True` 字符串命令改为参数列表调用。
- 为 `submit_to_google_indexing.py` 补充同目录导入路径，支持从任意工作目录或模块方式运行。
- 优化 `mkdocs_hooks.py` 的 Frontmatter 读取流程，让搜索索引 synonyms 注入和 sitemap noindex 裁剪复用同一份解析缓存。
- 同步更新 `docs/dev/Tools-Index.md` 的工具说明。

## 原因

这些调整修复工具脚本中的可维护性和可靠性问题：避免潜在命令拼接风险、减少运行方式对当前工作目录的依赖，并避免构建后处理阶段重复读取同一 Markdown 文件的 Frontmatter。

IndexNow 的公开验证 key 保持现有逻辑不变，因为该 key 需要以 `{key}.txt` 形式公开给 Bing/IndexNow 验证站点所有权。

## 验证

- `uv run python3 -m py_compile tools/mkdocs_hooks.py tools/gen_changelog_by_tags.py tools/submit_to_google_indexing.py`
- `uv run python3 -m py_compile tools/gen_changelog_by_tags.py tools/submit_to_google_indexing.py tools/submit_to_indexnow.py`
- `uv run python3 tools/check_links.py docs/entries/`
- `uv run python3 tools/check_tags.py docs/entries/`
- `uv run python3 tools/gen_changelog_by_tags.py --latest-to-head --output /tmp/mps-wiki-change.log`
- `uv run python3 -m tools.submit_to_google_indexing --help`
- `uv run mkdocs build`

备注：`uv run mkdocs build --strict` 会因仓库既有文档链接/锚点 warning 失败，非本次改动引入。