### PR TITLE
[codex] 修复 SEO 模板噪音

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 
+{% block htmltitle %}
+  {% if page and page.is_homepage %}
+    <title>{{ config.site_name }}</title>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
 
@@ -11,18 +19,22 @@
   <link rel="apple-touch-icon" sizes="180x180" href="{{ config.site_url }}assets/apple-touch-icon.png">
 
   {% if page %}
+  {% set social_title = config.site_name %}
+  {% if not page.is_homepage and page.title %}
+    {% set social_title = page.title ~ " - 多意识体系统百科" %}
+  {% endif %}
   <!-- Open Graph Meta Tags -->
   <meta property="og:site_name" content="Multiple Personality System Wiki - 多意识体系统百科">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ page.canonical_url }}">
-  <meta property="og:title" content="{% if page.title %}{{ page.title }} - {% endif %}多意识体系统百科">
+  <meta property="og:title" content="{{ social_title }}">
   <meta property="og:description" content="{% if page.meta and page.meta.description %}{{ page.meta.description }}{% else %}{{ config.site_description }}{% endif %}">
   <meta property="og:image" content="{{ config.site_url }}assets/images/og-banner.png">
   <meta property="og:locale" content="zh_CN">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{% if page.title %}{{ page.title }} - {% endif %}多意识体系统百科">
+  <meta name="twitter:title" content="{{ social_title }}">
   <meta name="twitter:description" content="{% if page.meta and page.meta.description %}{{ page.meta.description }}{% else %}{{ config.site_description }}{% endif %}">
   <meta name="twitter:image" content="{{ config.site_url }}assets/images/twitter-banner.png">
 
@@ -65,7 +77,6 @@
 
 {% block content %}
   {{ super() }}
-  {% include "partials/comments.html" %}
 {% endblock %}
 
 {% block analytics %}


### PR DESCRIPTION
## 变更说明
- 修复首页 `<title>` 被重复拼接站点名的问题
- 统一首页与内页的 OG/Twitter 标题生成逻辑
- 移除重复注入的评论区容器，减少页面模板噪音

## 原因
- 首页标题重复会制造不必要的 SEO 噪音
- `comments.html` 被额外 include 一次，导致内容区出现重复评论容器

## 影响
- 首页和社交分享标题更规范
- 词条页 HTML 结构更干净，减少重复组件输出
- 本次 PR 仅包含 `overrides/main.html`，不包含工作区里的其他未提交改动

## 验证
- `uv run python3 tools/check_links.py docs/entries/`
- `uv run python3 tools/check_tags.py docs/entries/`
- `uv run mkdocs build`
- 检查构建产物，确认首页标题恢复单一站点名，`entries/DID` 页面仅保留一个评论容器