### PR TITLE
[codex] 修正简式量表移动端表头与布局

### DIFF
--- a/docs/assets/brief-scales.css
+++ b/docs/assets/brief-scales.css
@@ -70,6 +70,14 @@
   table-layout: auto;
 }
 
+.brief-scale-table caption {
+  caption-side: top;
+  padding-bottom: 0.75rem;
+  text-align: center;
+  font-weight: 700;
+  color: var(--md-default-fg-color);
+}
+
 .brief-scale-item td {
   background: color-mix(in srgb, var(--md-primary-fg-color) 5%, transparent);
   padding: 0.55rem 0.6rem;
@@ -260,12 +268,108 @@
     grid-template-columns: 1fr;
   }
 
+  .brief-scale-grid {
+    grid-template-columns: 1fr;
+  }
+
   .brief-scale-ctrl {
     grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  .brief-scale-ctrl select,
+  .brief-scale-field select {
+    min-width: 0;
+    font-size: 0.82rem;
+    padding: 0.5rem 0.65rem;
   }
 
   .brief-scale-badge {
     width: auto;
     justify-self: start;
+    font-size: 0.82rem;
+  }
+
+  .brief-scale-table {
+    display: block;
+    overflow: visible;
+    border-spacing: 0 0.35rem;
+    font-size: 0.88rem;
+  }
+
+  .brief-scale-table caption {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding-bottom: 0.6rem;
+    text-align: left;
+    white-space: normal;
+    word-break: keep-all;
+  }
+
+  .brief-scale-table colgroup,
+  .brief-scale-table thead {
+    display: none;
+  }
+
+  .brief-scale-table tbody {
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .brief-scale-table .brief-scale-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "no prompt"
+      "control control";
+    gap: 0.35rem 0.75rem;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    background: color-mix(in srgb, var(--md-primary-fg-color) 5%, transparent);
+  }
+
+  [data-md-color-scheme="slate"] .brief-scale-table .brief-scale-item {
+    background: color-mix(in srgb, var(--md-primary-fg-color) 12%, #1b2331);
+  }
+
+  .brief-scale-item td {
+    display: block;
+    padding: 0;
+    background: transparent;
+  }
+
+  .brief-scale-item td:first-child,
+  .brief-scale-item td:last-child {
+    border-radius: 0;
+  }
+
+  .brief-scale-item td:nth-child(1) {
+    grid-area: no;
+    align-self: start;
+    padding-top: 0.1rem;
+  }
+
+  .brief-scale-item td:nth-child(2) {
+    grid-area: prompt;
+    font-weight: 600;
+    line-height: 1.55;
+  }
+
+  .brief-scale-item td:nth-child(3) {
+    grid-area: control;
+    padding-top: 0.15rem;
+  }
+
+  .brief-scale-no {
+    font-size: 0.82rem;
+  }
+
+  .brief-scale-score-value {
+    font-size: 0.95rem;
+  }
+
+  .brief-scale-score-card {
+    padding: 0.6rem 0.75rem;
   }
 }


### PR DESCRIPTION
## 变更内容
修正 PHQ-9 / GAD-7 等简式量表在移动端的题目区布局，并修复表头标题在手机端被错误压窄后逐字断行的问题。

## 原因
共享样式 `docs/assets/brief-scales.css` 之前没有为移动端提供完整的卡片化表格布局，且 `<caption>` 在手机端仍按原生表格 caption 规则参与宽度计算，导致题目标题与题干在窄屏下显示异常。

## 影响
移动端访问简式量表页面时，题号、题干、选择框和分数徽标会按更稳定的卡片结构展示；表头标题会正常横向显示，不再竖排断行。桌面端表格语义保持不变。

## 根因
问题来自共享量表样式对移动端断点覆盖不完整，尤其是表格 caption 和三列表格在小屏下缺少明确布局规则。

## 校验
- 核对 `docs/assets/brief-scales.css` 变更范围，仅包含共享样式修复
- 曾尝试运行 `uv run mkdocs build --strict`，但仓库存在与本次改动无关的既有告警，无法作为这次修复的干净通过信号
