### PR TITLE
fix: 修复在线量表导出图片右侧被裁切

### DIFF
--- a/docs/assets/brief-scales.js
+++ b/docs/assets/brief-scales.js
@@ -154,14 +154,15 @@
       await nextFrame();
       await nextFrame();
 
+      const PAD = 20;
       const dataUrl = await h2i.toJpeg(node, {
-        width: Math.ceil(node.scrollWidth + 2),
-        height: Math.ceil(node.scrollHeight + 2),
+        width: Math.ceil(node.scrollWidth + PAD * 2 + 2),
+        height: Math.ceil(node.scrollHeight + PAD * 2 + 2),
         cacheBust: true,
         pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
         backgroundColor: bg,
         style: {
-          padding: "20px",
+          padding: `${PAD}px`,
           boxSizing: "border-box",
           backgroundColor: bg
         }

--- a/docs/assets/mid60.js
+++ b/docs/assets/mid60.js
@@ -153,8 +153,10 @@
       await nextFrame();
 
       // 计算导出尺寸：使用 scrollWidth/scrollHeight 防止右侧被裁切
-      const width = Math.ceil(node.scrollWidth + 2);   // 加 2 像素避免取整误差
-      const height = Math.ceil(node.scrollHeight + 2);
+      // 由于使用 box-sizing: border-box + padding，需要额外补足 padding × 2 的宽高
+      const PAD = 20;
+      const width = Math.ceil(node.scrollWidth + PAD * 2 + 2);   // +2 避免取整误差，+PAD*2 补足 padding
+      const height = Math.ceil(node.scrollHeight + PAD * 2 + 2);
 
       let dataUrl = await h2i.toJpeg(node, {
         width,
@@ -163,7 +165,7 @@
         pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
         backgroundColor: bg,
         style: {
-          padding: '20px',
+          padding: `${PAD}px`,
           boxSizing: 'border-box',
           backgroundColor: bg
         }
@@ -182,7 +184,7 @@
             pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
             backgroundColor: bg,
             style: {
-              padding: '20px',
+              padding: `${PAD}px`,
               boxSizing: 'border-box',
               backgroundColor: bg
             }

--- a/docs/assets/sas.js
+++ b/docs/assets/sas.js
@@ -103,8 +103,9 @@
       await nextFrame();
       await nextFrame();
 
-      const width = Math.ceil(node.scrollWidth + 2);
-      const height = Math.ceil(node.scrollHeight + 2);
+      const PAD = 20;
+      const width = Math.ceil(node.scrollWidth + PAD * 2 + 2);
+      const height = Math.ceil(node.scrollHeight + PAD * 2 + 2);
 
       let dataUrl = await h2i.toJpeg(node, {
         width,
@@ -113,7 +114,7 @@
         pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
         backgroundColor: bg,
         style: {
-          padding: '20px',
+          padding: `${PAD}px`,
           boxSizing: 'border-box',
           backgroundColor: bg
         }
@@ -130,7 +131,7 @@
             pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
             backgroundColor: bg,
             style: {
-              padding: '20px',
+              padding: `${PAD}px`,
               boxSizing: 'border-box',
               backgroundColor: bg
             }

--- a/docs/assets/sds.js
+++ b/docs/assets/sds.js
@@ -101,8 +101,9 @@
       await nextFrame();
       await nextFrame();
 
-      const width = Math.ceil(node.scrollWidth + 2);
-      const height = Math.ceil(node.scrollHeight + 2);
+      const PAD = 20;
+      const width = Math.ceil(node.scrollWidth + PAD * 2 + 2);
+      const height = Math.ceil(node.scrollHeight + PAD * 2 + 2);
 
       let dataUrl = await h2i.toJpeg(node, {
         width,
@@ -111,7 +112,7 @@
         pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
         backgroundColor: bg,
         style: {
-          padding: '20px',
+          padding: `${PAD}px`,
           boxSizing: 'border-box',
           backgroundColor: bg
         }
@@ -128,7 +129,7 @@
             pixelRatio: Math.min(2, window.devicePixelRatio || 1.5),
             backgroundColor: bg,
             style: {
-              padding: '20px',
+              padding: `${PAD}px`,
               boxSizing: 'border-box',
               backgroundColor: bg
             }


### PR DESCRIPTION
## Summary
- 修复 PHQ-9 / GAD-7 / SAS / SDS / MID-60 在线评估"导出图片"功能：右侧文字（严重度标签、分数、阈值标注等）以及底部水印被裁切。
- 根因：`box-sizing: border-box` + `padding: 20px` 会压缩内容区域 40px，但 `html-to-image` 调用传入的 `width/height` 仍用 `scrollWidth/scrollHeight`，没补足 padding。
- 修复：统一在 brief-scales/sas/sds/mid60 的导出宽高上加 `PAD * 2`，让内容区域恢复原始尺寸。

## Test plan
- [x] 本地 `uv run mkdocs serve`，逐个打开 PHQ-9、GAD-7、SAS、SDS、MID-60 在线评估页面
- [x] 填若干题，点击"导出图片"
- [x] 检查导出图片：右侧文字完整（如"无或极轻"、"20-27 重度"、总分数字、严重度标签）、底部水印 `wiki.mpsteam.cn` 完整、四周保留约 20px 留白
- [ ] 桌面端和移动端各验证一次