### PR TITLE
[codex] 修复首页模板链接与 Giscus 回退逻辑

### DIFF
--- a/docs/assets/giscus-loader.js
+++ b/docs/assets/giscus-loader.js
@@ -42,12 +42,30 @@
   }
 
   /**
+   * 归一化配置值，过滤空串与常见占位值。
+   */
+  function normalizeConfigValue(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const normalized = `${value}`.trim();
+    if (!normalized) {
+      return '';
+    }
+    const lowered = normalized.toLowerCase();
+    if (lowered === 'none' || lowered === 'null' || lowered === 'undefined') {
+      return '';
+    }
+    return normalized;
+  }
+
+  /**
    * 解析配置。
    */
   function parseConfig(root) {
     const dataset = root.dataset;
-    const host = dataset.giscusHost && dataset.giscusHost.trim()
-      ? dataset.giscusHost.trim()
+    const host = normalizeConfigValue(dataset.giscusHost)
+      ? normalizeConfigValue(dataset.giscusHost)
       : DEFAULT_HOST;
     const clientSrc = resolveClientSrc(host);
 
@@ -59,18 +77,18 @@
     }
 
     return {
-      repo: dataset.giscusRepo,
-      repoId: dataset.giscusRepoId,
-      category: dataset.giscusCategory,
-      categoryId: dataset.giscusCategoryId,
-      mapping: dataset.giscusMapping || 'pathname',
-      strict: dataset.giscusStrict || '0',
-      reactionsEnabled: dataset.giscusReactionsEnabled || '1',
-      emitMetadata: dataset.giscusEmitMetadata || '0',
-      inputPosition: dataset.giscusInputPosition || 'top',
-      theme: dataset.giscusTheme || 'preferred_color_scheme',
-      lang: dataset.giscusLang || 'zh-CN',
-      loading: dataset.giscusLoading || 'lazy',
+      repo: normalizeConfigValue(dataset.giscusRepo),
+      repoId: normalizeConfigValue(dataset.giscusRepoId),
+      category: normalizeConfigValue(dataset.giscusCategory),
+      categoryId: normalizeConfigValue(dataset.giscusCategoryId),
+      mapping: normalizeConfigValue(dataset.giscusMapping) || 'pathname',
+      strict: normalizeConfigValue(dataset.giscusStrict) || '0',
+      reactionsEnabled: normalizeConfigValue(dataset.giscusReactionsEnabled) || '1',
+      emitMetadata: normalizeConfigValue(dataset.giscusEmitMetadata) || '0',
+      inputPosition: normalizeConfigValue(dataset.giscusInputPosition) || 'top',
+      theme: normalizeConfigValue(dataset.giscusTheme) || 'preferred_color_scheme',
+      lang: normalizeConfigValue(dataset.giscusLang) || 'zh-CN',
+      loading: normalizeConfigValue(dataset.giscusLoading) || 'lazy',
       host,
       clientSrc,
       origin

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,7 @@ search:
 === "参与贡献"
 
     - 阅读 [贡献指南](contributing/index.md) 了解协作流程与规范。
-    - 按照 [词条模板](TEMPLATE_ENTRY.md) 撰写新条目或修订现有内容。
+    - 按照 [词条模板](https://github.com/mps-team-cn/Multiple_personality_system_wiki/blob/main/docs/TEMPLATE_ENTRY.md) 撰写新条目或修订现有内容。
     - 提交前运行 `check_links.py` 与 `check_tags.py` 确保格式合规。
     - 遇到疑问？可通过 [GitHub Issues](https://github.com/mps-team-cn/Multiple_personality_system_wiki/issues) 反馈。
    

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,12 +1,18 @@
 {% set giscus = config.extra.giscus if config.extra.giscus is defined else {} %}
-{% if page.meta.comments and giscus %}
+{% set repo = giscus.repo | default('', true) | string | trim %}
+{% set repo_id = giscus.repo_id | default('', true) | string | trim %}
+{% set category = giscus.category | default('', true) | string | trim %}
+{% set category_id = giscus.category_id | default('', true) | string | trim %}
+{% set invalid_tokens = ['', 'none', 'null'] %}
+{% set giscus_ready = repo and category and repo_id | lower not in invalid_tokens and category_id | lower not in invalid_tokens %}
+{% if page.meta.comments and giscus_ready %}
   <section
     class="giscus-container"
     data-giscus-root
-    data-giscus-repo="{{ giscus.repo | default('') }}"
-    data-giscus-repo-id="{{ giscus.repo_id | default('') }}"
-    data-giscus-category="{{ giscus.category | default('') }}"
-    data-giscus-category-id="{{ giscus.category_id | default('') }}"
+    data-giscus-repo="{{ repo }}"
+    data-giscus-repo-id="{{ repo_id }}"
+    data-giscus-category="{{ category }}"
+    data-giscus-category-id="{{ category_id }}"
     data-giscus-mapping="{{ giscus.mapping | default('pathname') }}"
     data-giscus-strict="{{ giscus.strict | default('0') }}"
     data-giscus-reactions-enabled="{{ giscus.reactions_enabled | default('1') }}"
@@ -28,6 +34,24 @@
       <p>
         ⚠️ <strong>评论暂不可用</strong>：
         <span data-giscus-fallback-detail>评论系统尚未完成配置或暂时不可访问。</span>
+        如需留言，请前往
+        <a href="https://github.com/mps-team-cn/Multiple_personality_system_wiki/discussions" target="_blank" rel="noopener">
+          GitHub Discussions
+        </a>
+        参与讨论。
+      </p>
+    </div>
+  </section>
+{% elif page.meta.comments %}
+  <section class="giscus-container">
+    <div
+      class="giscus-fallback"
+      role="status"
+      aria-live="polite"
+    >
+      <p>
+        ⚠️ <strong>评论暂不可用</strong>：
+        <span>当前页面未完成 Giscus 配置，因此不会加载外部评论脚本。</span>
         如需留言，请前往
         <a href="https://github.com/mps-team-cn/Multiple_personality_system_wiki/discussions" target="_blank" rel="noopener">
           GitHub Discussions


### PR DESCRIPTION
## 变更内容
- 修复首页“词条模板”入口的坏链，改为可访问的 GitHub 模板链接
- 调整 Giscus 模板与前端加载逻辑，在 `repo_id` / `category_id` 缺失或被渲染为 `None` / `null` 时不再注入无效评论脚本
- 为未完成 Giscus 配置的页面提供明确的回退提示，避免 DID 等页面继续带着脏配置输出

## 修复原因
搜索覆盖校验导出显示首页 `/` 与 `entries/DID/` 存在异常。排查后确认其中包含两个页面级硬伤：
- 首页存在明确坏链
- DID 页面在评论未配置完成时仍输出无效的 Giscus 配置属性，继续尝试加载第三方脚本

## 影响
- 首页减少一个确定性的坏链
- 评论未配置完成的页面会稳定回退，不再注入无效外部脚本
- 构建产物对搜索抓取器更稳健，便于继续观察 Search Console 中的覆盖状态

## 验证
- `uv run python3 tools/check_links.py docs/entries/`
- `uv run python3 tools/check_tags.py docs/entries/`
- `uv run mkdocs build`

## 备注
- `uv run mkdocs build --strict` 仍会被仓库中已有的历史 warning 阻塞，本 PR 未处理那批存量问题。