### PR TITLE
[codex] 调整量表导出为桌面端直接下载

### DIFF
--- a/docs/assets/brief-scales.js
+++ b/docs/assets/brief-scales.js
@@ -137,7 +137,7 @@
     return window.htmlToImage;
   }
 
-  async function exportResultsImage(prefix, root, title, fileName) {
+  async function exportResultsImage(prefix, root, title, fileName, trigger) {
     const node = qs(`#${prefix}-results`, root);
     if (!node) return;
     let wm = null;
@@ -174,31 +174,19 @@
         file = new File([blob], `${fileName}.jpg`, { type: blob.type || "image/jpeg" });
       } catch (_) {}
 
-      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
-
-      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          files: [file],
-          title,
-          text: "来自 wiki.mpsteam.cn"
-        });
-        return;
+      const shareUtils = window.MPSShareUtils;
+      if (!shareUtils || typeof shareUtils.deliverExport !== "function") {
+        throw new Error("分享工具未加载");
       }
 
-      if (preferShare && navigator.clipboard && window.ClipboardItem) {
-        try {
-          await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
-          alert("图片已复制，可直接粘贴到聊天");
-          return;
-        } catch (_) {}
-      }
-
-      const a = document.createElement("a");
-      a.href = dataUrl;
-      a.download = `${fileName}.jpg`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      await shareUtils.deliverExport({
+        file,
+        blob,
+        dataUrl,
+        fileName: `${fileName}.jpg`,
+        title,
+        trigger
+      });
     } catch (err) {
       console.error(err);
       alert("导出失败，请重试");
@@ -297,7 +285,7 @@
       exportBtn.textContent = "导出图片";
       actions.appendChild(exportBtn);
     }
-    exportBtn.addEventListener("click", () => exportResultsImage(prefix, root, config.title, config.fileName));
+    exportBtn.addEventListener("click", () => exportResultsImage(prefix, root, config.title, config.fileName, exportBtn));
 
     root.addEventListener("change", (event) => {
       const target = event.target;

--- a/docs/assets/brief-scales.js
+++ b/docs/assets/brief-scales.js
@@ -137,24 +137,6 @@
     return window.htmlToImage;
   }
 
-  function shouldPreferNativeShare() {
-    const uaData = navigator.userAgentData;
-    if (uaData && typeof uaData.mobile === "boolean") {
-      return uaData.mobile;
-    }
-
-    const ua = navigator.userAgent || "";
-    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
-      return true;
-    }
-
-    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
-      return true;
-    }
-
-    return !!(window.matchMedia && window.matchMedia("(max-width: 760px) and (pointer: coarse)").matches);
-  }
-
   async function exportResultsImage(prefix, root, title, fileName) {
     const node = qs(`#${prefix}-results`, root);
     if (!node) return;
@@ -192,7 +174,7 @@
         file = new File([blob], `${fileName}.jpg`, { type: blob.type || "image/jpeg" });
       } catch (_) {}
 
-      const preferShare = shouldPreferNativeShare();
+      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
 
       if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({

--- a/docs/assets/brief-scales.js
+++ b/docs/assets/brief-scales.js
@@ -137,6 +137,24 @@
     return window.htmlToImage;
   }
 
+  function shouldPreferNativeShare() {
+    const uaData = navigator.userAgentData;
+    if (uaData && typeof uaData.mobile === "boolean") {
+      return uaData.mobile;
+    }
+
+    const ua = navigator.userAgent || "";
+    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
+      return true;
+    }
+
+    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
+      return true;
+    }
+
+    return !!(window.matchMedia && window.matchMedia("(max-width: 760px) and (pointer: coarse)").matches);
+  }
+
   async function exportResultsImage(prefix, root, title, fileName) {
     const node = qs(`#${prefix}-results`, root);
     if (!node) return;
@@ -174,7 +192,9 @@
         file = new File([blob], `${fileName}.jpg`, { type: blob.type || "image/jpeg" });
       } catch (_) {}
 
-      if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+      const preferShare = shouldPreferNativeShare();
+
+      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({
           files: [file],
           title,
@@ -183,7 +203,7 @@
         return;
       }
 
-      if (navigator.clipboard && window.ClipboardItem) {
+      if (preferShare && navigator.clipboard && window.ClipboardItem) {
         try {
           await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
           alert("图片已复制，可直接粘贴到聊天");

--- a/docs/assets/mid60.js
+++ b/docs/assets/mid60.js
@@ -132,6 +132,24 @@
     return window.htmlToImage;
   }
 
+  function shouldPreferNativeShare() {
+    const uaData = navigator.userAgentData;
+    if (uaData && typeof uaData.mobile === 'boolean') {
+      return uaData.mobile;
+    }
+
+    const ua = navigator.userAgent || '';
+    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
+      return true;
+    }
+
+    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
+      return true;
+    }
+
+    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
+  }
+
   async function exportResultsImage(root) {
     const node = qs('#mid60-results', root);
     if (!node) return;
@@ -198,8 +216,10 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* 某些旧浏览器不支持 File 构造器 */ }
 
-      // 优先使用系统分享（移动端友好）
-      if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+      const preferShare = shouldPreferNativeShare();
+
+      // 移动端优先使用系统分享，桌面端直接下载
+      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({
           files: [file],
           title: 'MID‑60 结果',
@@ -208,8 +228,8 @@
         return;
       }
 
-      // 次选：复制到剪贴板（部分浏览器支持）
-      if (navigator.clipboard && window.ClipboardItem) {
+      // 仅在移动端保留剪贴板兜底，桌面端直接下载
+      if (preferShare && navigator.clipboard && window.ClipboardItem) {
         try {
           await navigator.clipboard.write([
             new ClipboardItem({ [blob.type]: blob })
@@ -505,7 +525,7 @@
     const resetBtn = qs('#mid60-reset', root);
     if (resetBtn) resetBtn.addEventListener('click', () => resetAll(root));
 
-    // 导出按钮（移动端友好：系统分享 + 下载兜底）
+    // 导出按钮（移动端优先分享，桌面端直接下载）
     const actions = qs('.mid60-actions', root) || root;
     let exportBtn = qs('#mid60-export', actions);
     if (!exportBtn) {

--- a/docs/assets/mid60.js
+++ b/docs/assets/mid60.js
@@ -132,24 +132,6 @@
     return window.htmlToImage;
   }
 
-  function shouldPreferNativeShare() {
-    const uaData = navigator.userAgentData;
-    if (uaData && typeof uaData.mobile === 'boolean') {
-      return uaData.mobile;
-    }
-
-    const ua = navigator.userAgent || '';
-    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
-      return true;
-    }
-
-    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
-      return true;
-    }
-
-    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
-  }
-
   async function exportResultsImage(root) {
     const node = qs('#mid60-results', root);
     if (!node) return;
@@ -216,7 +198,7 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* 某些旧浏览器不支持 File 构造器 */ }
 
-      const preferShare = shouldPreferNativeShare();
+      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
 
       // 移动端优先使用系统分享，桌面端直接下载
       if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {

--- a/docs/assets/mid60.js
+++ b/docs/assets/mid60.js
@@ -132,7 +132,7 @@
     return window.htmlToImage;
   }
 
-  async function exportResultsImage(root) {
+  async function exportResultsImage(root, trigger) {
     const node = qs('#mid60-results', root);
     if (!node) return;
     let wm = null;
@@ -198,36 +198,19 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* 某些旧浏览器不支持 File 构造器 */ }
 
-      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
-
-      // 移动端优先使用系统分享，桌面端直接下载
-      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          files: [file],
-          title: 'MID‑60 结果',
-          text: '来自 wiki.mpsteam.cn'
-        });
-        return;
+      const shareUtils = window.MPSShareUtils;
+      if (!shareUtils || typeof shareUtils.deliverExport !== 'function') {
+        throw new Error('分享工具未加载');
       }
 
-      // 仅在移动端保留剪贴板兜底，桌面端直接下载
-      if (preferShare && navigator.clipboard && window.ClipboardItem) {
-        try {
-          await navigator.clipboard.write([
-            new ClipboardItem({ [blob.type]: blob })
-          ]);
-          alert('图片已复制，可直接粘贴到聊天');
-          return;
-        } catch (_) { /* 忽略 */ }
-      }
-
-      // 兜底：触发下载
-      const a = document.createElement('a');
-      a.href = dataUrl;
-      a.download = fileName;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      await shareUtils.deliverExport({
+        file,
+        blob,
+        dataUrl,
+        fileName,
+        title: 'MID‑60 结果',
+        trigger
+      });
     } catch (err) {
       console.error(err);
       alert('导出失败，请重试');
@@ -518,7 +501,7 @@
       exportBtn.textContent = '导出图片';
       actions.appendChild(exportBtn);
     }
-    exportBtn.addEventListener('click', () => exportResultsImage(root));
+    exportBtn.addEventListener('click', () => exportResultsImage(root, exportBtn));
 
     // 实时更新:任意滑块变动即刷新结果
     root.addEventListener('input', (e) => {

--- a/docs/assets/sas.js
+++ b/docs/assets/sas.js
@@ -85,24 +85,6 @@
     return window.htmlToImage;
   }
 
-  function shouldPreferNativeShare() {
-    const uaData = navigator.userAgentData;
-    if (uaData && typeof uaData.mobile === 'boolean') {
-      return uaData.mobile;
-    }
-
-    const ua = navigator.userAgent || '';
-    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
-      return true;
-    }
-
-    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
-      return true;
-    }
-
-    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
-  }
-
   async function exportResultsImage(root) {
     const node = qs('#sas-results', root);
     if (!node) return;
@@ -164,7 +146,7 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* ignore */ }
 
-      const preferShare = shouldPreferNativeShare();
+      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
 
       if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({

--- a/docs/assets/sas.js
+++ b/docs/assets/sas.js
@@ -85,6 +85,24 @@
     return window.htmlToImage;
   }
 
+  function shouldPreferNativeShare() {
+    const uaData = navigator.userAgentData;
+    if (uaData && typeof uaData.mobile === 'boolean') {
+      return uaData.mobile;
+    }
+
+    const ua = navigator.userAgent || '';
+    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
+      return true;
+    }
+
+    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
+      return true;
+    }
+
+    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
+  }
+
   async function exportResultsImage(root) {
     const node = qs('#sas-results', root);
     if (!node) return;
@@ -146,7 +164,9 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* ignore */ }
 
-      if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+      const preferShare = shouldPreferNativeShare();
+
+      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({
           files: [file],
           title: 'SAS 焦虑自评量表结果',
@@ -155,7 +175,7 @@
         return;
       }
 
-      if (navigator.clipboard && window.ClipboardItem) {
+      if (preferShare && navigator.clipboard && window.ClipboardItem) {
         try {
           await navigator.clipboard.write([
             new ClipboardItem({ [blob.type]: blob })

--- a/docs/assets/sas.js
+++ b/docs/assets/sas.js
@@ -85,7 +85,7 @@
     return window.htmlToImage;
   }
 
-  async function exportResultsImage(root) {
+  async function exportResultsImage(root, trigger) {
     const node = qs('#sas-results', root);
     if (!node) return;
     let wm = null;
@@ -146,33 +146,19 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* ignore */ }
 
-      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
-
-      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          files: [file],
-          title: 'SAS 焦虑自评量表结果',
-          text: '来自 wiki.mpsteam.cn'
-        });
-        return;
+      const shareUtils = window.MPSShareUtils;
+      if (!shareUtils || typeof shareUtils.deliverExport !== 'function') {
+        throw new Error('分享工具未加载');
       }
 
-      if (preferShare && navigator.clipboard && window.ClipboardItem) {
-        try {
-          await navigator.clipboard.write([
-            new ClipboardItem({ [blob.type]: blob })
-          ]);
-          alert('图片已复制，可直接粘贴到聊天');
-          return;
-        } catch (_) { /* ignore */ }
-      }
-
-      const a = document.createElement('a');
-      a.href = dataUrl;
-      a.download = fileName;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      await shareUtils.deliverExport({
+        file,
+        blob,
+        dataUrl,
+        fileName,
+        title: 'SAS 焦虑自评量表结果',
+        trigger
+      });
     } catch (err) {
       console.error(err);
       alert('导出失败，请重试');
@@ -338,7 +324,7 @@
       exportBtn.textContent = '导出图片';
       actions.appendChild(exportBtn);
     }
-    exportBtn.addEventListener('click', () => exportResultsImage(root));
+    exportBtn.addEventListener('click', () => exportResultsImage(root, exportBtn));
 
     // 实时更新结果
     root.addEventListener('change', (e) => {

--- a/docs/assets/sds.js
+++ b/docs/assets/sds.js
@@ -83,7 +83,7 @@
     return window.htmlToImage;
   }
 
-  async function exportResultsImage(root) {
+  async function exportResultsImage(root, trigger) {
     const node = qs('#sds-results', root);
     if (!node) return;
     let wm = null;
@@ -144,33 +144,19 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* ignore */ }
 
-      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
-
-      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          files: [file],
-          title: 'SDS 抑郁自评量表结果',
-          text: '来自 wiki.mpsteam.cn'
-        });
-        return;
+      const shareUtils = window.MPSShareUtils;
+      if (!shareUtils || typeof shareUtils.deliverExport !== 'function') {
+        throw new Error('分享工具未加载');
       }
 
-      if (preferShare && navigator.clipboard && window.ClipboardItem) {
-        try {
-          await navigator.clipboard.write([
-            new ClipboardItem({ [blob.type]: blob })
-          ]);
-          alert('图片已复制，可直接粘贴到聊天');
-          return;
-        } catch (_) { /* ignore */ }
-      }
-
-      const a = document.createElement('a');
-      a.href = dataUrl;
-      a.download = fileName;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      await shareUtils.deliverExport({
+        file,
+        blob,
+        dataUrl,
+        fileName,
+        title: 'SDS 抑郁自评量表结果',
+        trigger
+      });
     } catch (err) {
       console.error(err);
       alert('导出失败，请重试');
@@ -284,7 +270,7 @@
       exportBtn.textContent = '导出图片';
       actions.appendChild(exportBtn);
     }
-    exportBtn.addEventListener('click', () => exportResultsImage(root));
+    exportBtn.addEventListener('click', () => exportResultsImage(root, exportBtn));
 
     // 实时更新结果
     root.addEventListener('change', (e) => {

--- a/docs/assets/sds.js
+++ b/docs/assets/sds.js
@@ -83,6 +83,24 @@
     return window.htmlToImage;
   }
 
+  function shouldPreferNativeShare() {
+    const uaData = navigator.userAgentData;
+    if (uaData && typeof uaData.mobile === 'boolean') {
+      return uaData.mobile;
+    }
+
+    const ua = navigator.userAgent || '';
+    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
+      return true;
+    }
+
+    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
+      return true;
+    }
+
+    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
+  }
+
   async function exportResultsImage(root) {
     const node = qs('#sds-results', root);
     if (!node) return;
@@ -144,7 +162,9 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* ignore */ }
 
-      if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+      const preferShare = shouldPreferNativeShare();
+
+      if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({
           files: [file],
           title: 'SDS 抑郁自评量表结果',
@@ -153,7 +173,7 @@
         return;
       }
 
-      if (navigator.clipboard && window.ClipboardItem) {
+      if (preferShare && navigator.clipboard && window.ClipboardItem) {
         try {
           await navigator.clipboard.write([
             new ClipboardItem({ [blob.type]: blob })

--- a/docs/assets/sds.js
+++ b/docs/assets/sds.js
@@ -83,24 +83,6 @@
     return window.htmlToImage;
   }
 
-  function shouldPreferNativeShare() {
-    const uaData = navigator.userAgentData;
-    if (uaData && typeof uaData.mobile === 'boolean') {
-      return uaData.mobile;
-    }
-
-    const ua = navigator.userAgent || '';
-    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
-      return true;
-    }
-
-    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
-      return true;
-    }
-
-    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
-  }
-
   async function exportResultsImage(root) {
     const node = qs('#sds-results', root);
     if (!node) return;
@@ -162,7 +144,7 @@
         file = new File([blob], fileName, { type: blob.type || 'image/jpeg' });
       } catch (_) { /* ignore */ }
 
-      const preferShare = shouldPreferNativeShare();
+      const preferShare = !!window.MPSShareUtils?.shouldPreferNativeShare?.();
 
       if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
         await navigator.share({

--- a/docs/assets/share-utils.js
+++ b/docs/assets/share-utils.js
@@ -1,0 +1,30 @@
+/**
+ * 量表导出相关的共享判定工具。
+ * 当前用于区分“移动端优先系统分享”和“桌面端直接下载”。
+ */
+(function () {
+  function shouldPreferNativeShare() {
+    const uaData = navigator.userAgentData;
+    if (uaData && typeof uaData.mobile === 'boolean') {
+      return uaData.mobile;
+    }
+
+    const ua = navigator.userAgent || '';
+    if (/Android|iPhone|iPad|iPod|Windows Phone|Mobile/i.test(ua)) {
+      return true;
+    }
+
+    // iPadOS 13+ 可能伪装为桌面端 UA，但仍然具备多点触控。
+    if (/Macintosh/i.test(ua) && navigator.maxTouchPoints > 1) {
+      return true;
+    }
+
+    return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
+  }
+
+  if (typeof window !== 'undefined') {
+    window.MPSShareUtils = Object.assign({}, window.MPSShareUtils, {
+      shouldPreferNativeShare
+    });
+  }
+})();

--- a/docs/assets/share-utils.js
+++ b/docs/assets/share-utils.js
@@ -22,9 +22,63 @@
     return !!(window.matchMedia && window.matchMedia('(max-width: 760px) and (pointer: coarse)').matches);
   }
 
+  function flashDownloadFeedback(trigger) {
+    if (!trigger || typeof trigger.textContent !== 'string') return;
+
+    const originalText = trigger.dataset.exportOriginalText || trigger.textContent;
+    trigger.dataset.exportOriginalText = originalText;
+    trigger.textContent = '已开始下载';
+
+    window.setTimeout(() => {
+      trigger.textContent = originalText;
+    }, 1800);
+  }
+
+  async function deliverExport(options) {
+    const {
+      file,
+      blob,
+      dataUrl,
+      fileName,
+      title,
+      text = '来自 wiki.mpsteam.cn',
+      trigger
+    } = options;
+
+    const preferShare = shouldPreferNativeShare();
+
+    if (preferShare && file && navigator.canShare && navigator.canShare({ files: [file] })) {
+      await navigator.share({
+        files: [file],
+        title,
+        text
+      });
+      return 'shared';
+    }
+
+    if (preferShare && blob && navigator.clipboard && window.ClipboardItem) {
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({ [blob.type]: blob })
+        ]);
+        alert('图片已复制，可直接粘贴到聊天');
+        return 'copied';
+      } catch (_) { /* ignore */ }
+    }
+
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    flashDownloadFeedback(trigger);
+    return 'downloaded';
+  }
+
   if (typeof window !== 'undefined') {
-    window.MPSShareUtils = Object.assign({}, window.MPSShareUtils, {
-      shouldPreferNativeShare
-    });
+    window.MPSShareUtils = window.MPSShareUtils || {};
+    window.MPSShareUtils.shouldPreferNativeShare = shouldPreferNativeShare;
+    window.MPSShareUtils.deliverExport = deliverExport;
   }
 })();

--- a/docs/entries/Generalized-Anxiety-Disorder-7-GAD-7.md
+++ b/docs/entries/Generalized-Anxiety-Disorder-7-GAD-7.md
@@ -31,6 +31,7 @@ extra_css:
 
 extra_javascript:
 
+    - assets/share-utils.js
     - assets/brief-scales.js
 
 comments: true

--- a/docs/entries/Multidimensional-Inventory-of-Dissociation-MID-60.md
+++ b/docs/entries/Multidimensional-Inventory-of-Dissociation-MID-60.md
@@ -9,6 +9,7 @@ extra_css:
 
 extra_javascript:
 
+- assets/share-utils.js
 - assets/mid60.js
 
 search:

--- a/docs/entries/Patient-Health-Questionnaire-9-PHQ-9.md
+++ b/docs/entries/Patient-Health-Questionnaire-9-PHQ-9.md
@@ -31,6 +31,7 @@ extra_css:
 
 extra_javascript:
 
+    - assets/share-utils.js
     - assets/brief-scales.js
 
 comments: true

--- a/docs/entries/Self-Rating-Anxiety-Scale-SAS.md
+++ b/docs/entries/Self-Rating-Anxiety-Scale-SAS.md
@@ -28,6 +28,7 @@ extra_css:
 
 extra_javascript:
 
+    - assets/share-utils.js
     - assets/sas.js
 
 comments: true

--- a/docs/entries/Self-Rating-Depression-Scale-SDS.md
+++ b/docs/entries/Self-Rating-Depression-Scale-SDS.md
@@ -28,6 +28,7 @@ extra_css:
 
 extra_javascript:
 
+    - assets/share-utils.js
     - assets/sds.js
 
 comments: true

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -61,8 +61,6 @@
     {% endfor %}
   {% endif %}
 
-  <script defer src="{{ 'assets/share-utils.js' | url }}"></script>
-
   {% if page and page.meta and page.meta.extra_javascript %}
     {% for path in page.meta.extra_javascript %}
   <script defer src="{{ path | url }}"></script>

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -61,6 +61,8 @@
     {% endfor %}
   {% endif %}
 
+  <script defer src="{{ 'assets/share-utils.js' | url }}"></script>
+
   {% if page and page.meta and page.meta.extra_javascript %}
     {% for path in page.meta.extra_javascript %}
   <script defer src="{{ path | url }}"></script>


### PR DESCRIPTION
## 变更说明

本 PR 统一调整站内量表结果图片的导出行为：桌面端点击后直接下载图片，移动端继续优先使用系统分享。

## 修改内容

- 在 `docs/assets/mid60.js` 中调整 MID-60 的导出分支
- 在 `docs/assets/sds.js` 中调整 SDS 的导出分支
- 在 `docs/assets/sas.js` 中调整 SAS 的导出分支
- 在 `docs/assets/brief-scales.js` 中调整 PHQ-9 / GAD-7 共用导出分支
- 为上述脚本补充移动设备判定逻辑 `shouldPreferNativeShare()`
- 保留移动端分享与剪贴板兜底，桌面端不再优先尝试分享或复制

## 原因

现有逻辑主要按浏览器能力分支，导致 PC 端点击“导出图片”时也可能先进入分享或剪贴板路径，不符合桌面端用户对“直接下载”的预期。

## 影响

- PC 端导出结果图片的行为更稳定、预期更明确
- 手机端现有分享体验保持不变
- 其余量表页的导出体验与 MID-60 保持一致

## 验证

- `uv run python3 tools/check_links.py docs/entries/`
- `uv run python3 tools/check_tags.py docs/entries/`
- `node --check docs/assets/mid60.js`
- `node --check docs/assets/sds.js`
- `node --check docs/assets/sas.js`
- `node --check docs/assets/brief-scales.js`
