### PR TITLE
[codex] 新增 Makefile 统一维护入口

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,7 +39,8 @@
   uv sync
   ```
 
-- 所有 Python 命令通过 `uv run` 执行，例如 `uv run python3 tools/fix_markdown.py .`
+- 优先使用仓库根目录 `Makefile` 作为统一入口，例如 `make check`、`make build`、`make serve`、`make pdf`
+- 所有底层 Python 命令仍通过 `uv run` 执行，例如 `uv run python3 tools/fix_markdown.py .`
 - 常见问题：`externally-managed-environment` → 使用 uv 自动管理虚拟环境
 
 ### 自动化工具
@@ -47,10 +48,16 @@
 - **CI 双重检查机制**：
     - **PR 阶段**：自动检查链接规范和 Frontmatter 格式，发现问题会阻止合并
     - **合并后**：自动更新时间戳、修复格式、再次验证链接，确保质量
+- 推荐命令入口：
+    - `make check`：聚合链接、标签、Frontmatter 和默认构建检查
+    - `make build`：执行当前 `Makefile` 中定义的默认 MkDocs 构建
+    - `make serve`：启动本地预览
+    - `make pdf`：按默认参数导出 PDF 到 `releases/Multiple_Personality_System_wiki.pdf`
+- 若需要额外暴露 MkDocs warning，可单独运行 `uv run mkdocs build --strict`
 - 视任务执行 `markdownlint` 校验（可选）
 - 所有 Python 工具默认使用 `python3`
 - 大规模修改前必须确认相关索引、导览同步更新
-- 如需手动修复格式：`python3 tools/fix_markdown.py .`（CI 会自动处理，通常不需要）
+- 如需手动修复格式：优先 `make fix`；需要直接调脚本时使用 `uv run python3 tools/fix_markdown.py .`（CI 会自动处理，通常不需要）
 
 ## MANDATORY WORKFLOWS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@
 ┌─ 开发/修改工具?
 │  ├─ 修改 tools/*.py
 │  ├─ 同步更新 docs/dev/Tools-Index.md
-│  └─ 命令使用 uv run python3(不是裸 python3)
+│  └─ 优先使用 make；底层 Python 命令仍使用 uv run python3(不是裸 python3)
 │
 ┌─ 大规模重构?
 │  ├─ 先列影响范围
@@ -48,9 +48,9 @@
 │  └─ PR 说明自动化方法(正则/脚本/范围)
 │
 └─ 提交前检查
-   ├─ uv run python3 tools/check_links.py docs/entries/
-   ├─ uv run python3 tools/check_tags.py docs/entries/
-   └─ uv run mkdocs build --strict(可选)
+   ├─ make check
+   ├─ make build
+   └─ uv run mkdocs build --strict(额外严格检查,可选)
 ```
 
 ---
@@ -255,15 +255,19 @@ search:
 ### 6.1 本地检查(提交前必做)
 
 ```bash
-# 1. 检查链接规范
-uv run python3 tools/check_links.py docs/entries/
+# 1. 推荐统一入口
+make check
+make build
 
-# 2. 检查标签规范
-uv run python3 tools/check_tags.py docs/entries/
-
-# 3. (可选)构建测试
+# 2. (可选)额外严格构建测试
 uv run mkdocs build --strict
 ```
+
+说明：
+
+- `make check` 会聚合执行链接、标签、Frontmatter 和默认构建检查。
+- `make build` 使用当前 `Makefile` 中定义的默认 MkDocs 构建命令。
+- 若需要额外暴露 warning，可再运行 `uv run mkdocs build --strict`。
 
 ### 6.2 CI 双重检查机制
 
@@ -451,7 +455,7 @@ uv run python3 tools/check_tags.py docs/entries/
 |------|------|------|
 | `check_links.py` 报错 | 使用了绝对路径或错误相对路径 | 查看 [§5.1 链接路径速查表](#51-链接路径速查表) |
 | CI `pr-check` 失败 | Frontmatter 缺失字段或链接不规范 | 查看 CI 日志具体错误,修复后重新推送 |
-| `mkdocs build` 失败 | 导航配置或链接损坏 | 运行 `uv run mkdocs build --strict` 查看详细错误 |
+| `make build` 失败 | 导航配置或链接损坏 | 先运行 `make build` 复现,再用 `uv run mkdocs build --strict` 查看详细 warning |
 | 标签验证失败 | 标签格式不符或使用了别名 | 运行 `check_tags.py` 查看具体问题 |
 
 ### 11.2 快速命令参考
@@ -461,15 +465,20 @@ uv run python3 tools/check_tags.py docs/entries/
 uv sync
 
 # 本地预览
-uv run mkdocs serve  # 访问 http://127.0.0.1:8000
+make serve  # 访问 http://127.0.0.1:8000
 
 # 提交前检查
-uv run python3 tools/check_links.py docs/entries/
-uv run python3 tools/check_tags.py docs/entries/
+make check
+make build
+
+# 额外严格检查(可选)
 uv run mkdocs build --strict
 
+# PDF 导出
+make pdf
+
 # 格式修复(CI 会自动执行,通常无需手动)
-uv run python3 tools/fix_markdown.py docs/entries/
+make fix
 ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+SHELL := /bin/sh
+
+UV ?= uv
+PYTHON ?= python3
+ENTRIES_DIR ?= docs/entries
+MARKDOWNLINT ?= markdownlint
+MARKDOWN_FILES ?= docs/**/*.md
+PDF_ENGINE ?= tectonic
+CJK_FONT ?= Microsoft YaHei
+PDF_OUTPUT ?=
+PDF_EXTRA_ARGS ?=
+
+.PHONY: help links tags frontmatter build serve pdf fix lint check all
+
+help:
+	@printf '%s\n' \
+		'可用命令:' \
+		'  make help         查看帮助' \
+		'  make links        检查词条链接规范' \
+		'  make tags         检查词条标签规范' \
+		'  make frontmatter  检查词条 Frontmatter' \
+		'  make build        严格构建 MkDocs 站点' \
+		'  make serve        启动本地预览服务' \
+		'  make pdf          导出 PDF' \
+		'  make fix          修复 docs/entries/ 下的 Markdown 格式' \
+		'  make lint         运行 markdownlint' \
+		'  make check        依次执行 links/tags/frontmatter/build' \
+		'  make all          执行 check 和 pdf' \
+		'' \
+		'常用变量:' \
+		'  ENTRIES_DIR=docs/entries' \
+		'  PDF_ENGINE=tectonic' \
+		'  CJK_FONT=Microsoft YaHei' \
+		'  PDF_OUTPUT=Multiple_Personality_System_wiki.pdf' \
+		'  PDF_EXTRA_ARGS=...' \
+		'' \
+		'示例:' \
+		'  make check' \
+		'  make pdf PDF_ENGINE=xelatex CJK_FONT="Noto Serif CJK SC"' \
+		'  make pdf PDF_OUTPUT=dist/wiki.pdf PDF_EXTRA_ARGS='\''--include-tags "guide:入门指南"'\'''
+
+links:
+	$(UV) run $(PYTHON) tools/check_links.py $(ENTRIES_DIR)/
+
+tags:
+	$(UV) run $(PYTHON) tools/check_tags.py $(ENTRIES_DIR)/
+
+frontmatter:
+	$(UV) run $(PYTHON) tools/check_frontmatter.py --path $(ENTRIES_DIR)
+
+build:
+	$(UV) run mkdocs build --strict
+
+serve:
+	$(UV) run mkdocs serve
+
+pdf:
+	@set -- $(UV) run $(PYTHON) tools/pdf_export/export_to_pdf.py --pdf-engine "$(PDF_ENGINE)" --cjk-font "$(CJK_FONT)"; \
+	if [ -n "$(strip $(PDF_OUTPUT))" ]; then \
+		set -- "$$@" --output "$(PDF_OUTPUT)"; \
+	fi; \
+	if [ -n "$(strip $(PDF_EXTRA_ARGS))" ]; then \
+		set -- "$$@" $(PDF_EXTRA_ARGS); \
+	fi; \
+	"$$@"
+
+fix:
+	$(UV) run $(PYTHON) tools/fix_markdown.py $(ENTRIES_DIR)/
+
+lint:
+	$(MARKDOWNLINT) "$(MARKDOWN_FILES)" --ignore "node_modules" --ignore "tools/pdf_export/vendor"
+
+check: links tags frontmatter build
+
+all: check pdf

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MARKDOWNLINT ?= markdownlint
 MARKDOWN_FILES ?= docs/**/*.md
 PDF_ENGINE ?= tectonic
 CJK_FONT ?= Microsoft YaHei
-PDF_OUTPUT ?=
+PDF_OUTPUT ?= releases/Multiple_Personality_System_wiki.pdf
 PDF_EXTRA_ARGS ?=
 
 .PHONY: help links tags frontmatter build serve pdf fix lint check all
@@ -31,7 +31,7 @@ help:
 		'  ENTRIES_DIR=docs/entries' \
 		'  PDF_ENGINE=tectonic' \
 		'  CJK_FONT=Microsoft YaHei' \
-		'  PDF_OUTPUT=Multiple_Personality_System_wiki.pdf' \
+		'  PDF_OUTPUT=releases/Multiple_Personality_System_wiki.pdf' \
 		'  PDF_EXTRA_ARGS=...' \
 		'' \
 		'示例:' \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ frontmatter:
 	$(UV) run $(PYTHON) tools/check_frontmatter.py --path $(ENTRIES_DIR)
 
 build:
-	$(UV) run mkdocs build --strict
+	$(UV) run mkdocs build
 
 serve:
 	$(UV) run mkdocs serve

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 		'  make links        检查词条链接规范' \
 		'  make tags         检查词条标签规范' \
 		'  make frontmatter  检查词条 Frontmatter' \
-		'  make build        严格构建 MkDocs 站点' \
+		'  make build        构建 MkDocs 站点' \
 		'  make serve        启动本地预览服务' \
 		'  make pdf          导出 PDF' \
 		'  make fix          修复 docs/entries/ 下的 Markdown 格式' \

--- a/docs/dev/Tools-Index.md
+++ b/docs/dev/Tools-Index.md
@@ -24,6 +24,8 @@ make pdf PDF_ENGINE=xelatex CJK_FONT="Noto Serif CJK SC"
 make pdf PDF_OUTPUT=dist/wiki.pdf
 ```
 
+默认情况下，`make pdf` 会使用 `tectonic` 作为 PDF 引擎、`Microsoft YaHei` 作为中文字体，并输出到 `releases/Multiple_Personality_System_wiki.pdf`。
+
 ### 一键执行日常维护
 
 ```bash

--- a/docs/dev/Tools-Index.md
+++ b/docs/dev/Tools-Index.md
@@ -6,6 +6,24 @@
 
 ## 🚀 快速开始
 
+### Makefile 统一入口
+
+```bash
+make help
+make check
+make pdf
+make serve
+```
+
+`Makefile` 统一封装了常用的校验、构建、预览、PDF 导出和 Markdown 修复命令，内部默认使用 `uv run` 调用 Python 与 MkDocs 工具。
+
+PDF 导出支持通过变量覆盖默认参数：
+
+```bash
+make pdf PDF_ENGINE=xelatex CJK_FONT="Noto Serif CJK SC"
+make pdf PDF_OUTPUT=dist/wiki.pdf
+```
+
 ### 一键执行日常维护
 
 ```bash
@@ -31,6 +49,9 @@ bash tools/run_local_updates.sh --help
 
 | 任务 | 命令 |
 |------|------|
+| 查看统一入口帮助 | `make help` |
+| 一键执行常用检查 | `make check` |
+| 导出 PDF | `make pdf` |
 | 修复 Markdown 格式 | `python3 tools/fix_markdown.py docs/entries/` |
 | 检查链接规范 | `python3 tools/check_links.py docs/entries/` |
 | 检查 Frontmatter | `python3 tools/check_frontmatter.py` |
@@ -42,8 +63,8 @@ bash tools/run_local_updates.sh --help
 | 生成 SEO URL 列表 | `python3 tools/generate_seo_urls.py` |
 | 提交到 Google Indexing API | `python3 tools/submit_to_google_indexing.py` |
 | 提交到 IndexNow | `python3 tools/submit_to_indexnow.py --recent 50` |
-| 本地预览 | `mkdocs serve` |
-| 构建静态站点 | `mkdocs build` |
+| 本地预览 | `make serve` |
+| 构建静态站点 | `make build` |
 
 ## 📦 核心自动化工具(CI 集成)
 


### PR DESCRIPTION
## 变更内容

- 新增根目录 `Makefile`，统一封装常用维护命令：`help`、`links`、`tags`、`frontmatter`、`build`、`serve`、`pdf`、`fix`、`lint`、`check`、`all`
- 为 PDF 导出提供可覆盖变量：`PDF_ENGINE`、`CJK_FONT`、`PDF_OUTPUT`、`PDF_EXTRA_ARGS`
- 更新 `docs/dev/Tools-Index.md`，补充 `make` 统一入口和常用示例

## 变更原因

当前仓库的常用维护操作分散在多个脚本和命令里，日常执行 PDF 导出、校验、构建和预览时需要记忆多条命令。新增 `Makefile` 后，可以把高频维护操作收口到统一入口，降低使用成本。

## 影响

- 开发者可以直接使用 `make check`、`make pdf`、`make serve` 等命令完成高频维护任务
- 现有 `tools/run_local_updates.sh` / `.bat` 继续保留，不替代现有脚本流程
- 文档增加 `make` 用法说明，便于后续维护者发现统一入口

## 校验

- [x] `make help`
- [x] `make pdf PDF_OUTPUT=tmp/mps-wiki-test.pdf`
- [x] `make links`
- [x] `make tags`
- [x] `make frontmatter`
- [x] `make build`

`make build` 当前会因仓库现有的 MkDocs strict warning 失败，包括既有的 `changelog.md` 失效链接、若干词条锚点缺失等问题；这些不是本次改动引入的回归。
