### PR TITLE
[codex] 新增 ECR 中文版量表词条

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -334,6 +334,7 @@
         * [情绪调节（Emotion Regulation）](entries/Emotion-Regulation.md)
         * [想象性陪伴（Imaginary Companions）](entries/Imaginary-Companion.md)
         * [成人依恋（Adult Attachment）](entries/Adult-Attachment.md)
+        * [亲密关系经历量表中文版（Experiences in Close Relationships, ECR）](entries/Experiences-in-Close-Relationships-ECR-Chinese.md)
         * [投射（Projection, Psychology）](entries/Projection-Psychology.md)
         * [注意与觉察（Attention & Awareness）](entries/Attention-Awareness.md)
         * [社会认知理论（Social-Cognitive Theory）](entries/Social-Cognitive-Theory.md)

--- a/docs/assets/brief-scales.css
+++ b/docs/assets/brief-scales.css
@@ -106,6 +106,8 @@
   grid-template-columns: minmax(12rem, 1fr) auto;
   gap: 0.5rem;
   align-items: center;
+  --slider-offset-y: 0.13rem;
+  font-size: 0;
 }
 
 .brief-scale-ctrl select,
@@ -128,6 +130,49 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-primary-fg-color) 15%, transparent);
 }
 
+.brief-scale-ctrl input[type="range"] {
+  width: 100%;
+  min-width: 12rem;
+  touch-action: pan-y;
+  --r-track-h: 0.56rem;
+  --r-thumb-d: 1.1rem;
+  --r-thumb-offset-y: var(--slider-offset-y, 0.08rem);
+}
+
+.brief-scale-ctrl input[type="range"]::-webkit-slider-runnable-track {
+  height: var(--r-track-h);
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.brief-scale-ctrl input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  margin-top: calc((var(--r-track-h) - var(--r-thumb-d)) / 2 + var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.brief-scale-ctrl input[type="range"]::-moz-range-track {
+  height: var(--r-track-h);
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.brief-scale-ctrl input[type="range"]::-moz-range-thumb {
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  transform: translateY(var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
 .brief-scale-badge {
   display: inline-flex;
   align-items: center;
@@ -139,6 +184,8 @@
   color: var(--md-primary-fg-color);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  transform: translateY(var(--slider-offset-y, 0));
 }
 
 .brief-scale-badge::after {
@@ -273,21 +320,27 @@
   }
 
   .brief-scale-ctrl {
-    grid-template-columns: 1fr;
-    gap: 0.35rem;
+    grid-template-columns: 1fr auto;
+    gap: 0.45rem 0.5rem;
   }
 
-  .brief-scale-ctrl select,
   .brief-scale-field select {
     min-width: 0;
     font-size: 0.82rem;
     padding: 0.5rem 0.65rem;
   }
 
+  .brief-scale-ctrl select,
+  .brief-scale-ctrl input[type="range"] {
+    width: 100%;
+    min-width: 0;
+  }
+
   .brief-scale-badge {
-    width: auto;
-    justify-self: start;
-    font-size: 0.82rem;
+    width: 4.2rem;
+    justify-self: end;
+    align-self: center;
+    font-size: 0.9rem;
   }
 
   .brief-scale-table {

--- a/docs/assets/brief-scales.js
+++ b/docs/assets/brief-scales.js
@@ -123,6 +123,24 @@
     if (node) node.textContent = text;
   }
 
+  function itemNumberFromId(id) {
+    const match = String(id || "").match(/(\d+)$/);
+    return match ? match[1] : "";
+  }
+
+  function selectToRange(select) {
+    const input = document.createElement("input");
+    input.id = select.id;
+    input.type = "range";
+    input.min = "0";
+    input.max = "3";
+    input.step = "1";
+    input.value = select.value || "0";
+    input.setAttribute("tabindex", "0");
+    select.replaceWith(input);
+    return input;
+  }
+
   async function ensureHtmlToImage() {
     if (window.htmlToImage) return window.htmlToImage;
     const src = "https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.min.js";
@@ -198,29 +216,34 @@
   }
 
   function bindSelect(prefix, item) {
-    const select = qs("select", item);
+    let control = qs('input[type="range"], select', item);
     const badge = qs(".brief-scale-badge", item);
-    if (!select || !badge) return;
+    if (!control || !badge) return;
+
+    if (control.matches("select")) {
+      control = selectToRange(control);
+    }
 
     const questionText = item.querySelector("td:nth-child(2)")?.textContent?.trim() || "";
-    if (!select.hasAttribute("aria-label")) {
-      select.setAttribute(
+    if (!control.hasAttribute("aria-label")) {
+      control.setAttribute(
         "aria-label",
-        `${prefix.toUpperCase()} 题目 ${select.id.replace("item", "")}: ${questionText.substring(0, 40)}`
+        `${prefix.toUpperCase()} 题目 ${itemNumberFromId(control.id)}: ${questionText.substring(0, 40)} - 评分 0 到 3`
       );
     }
 
     const update = () => {
-      const value = Number(select.value || 0);
+      const value = Number(control.value || 0);
       badge.textContent = String(value);
     };
 
-    select.addEventListener("change", update);
+    control.addEventListener("input", update);
+    control.addEventListener("change", update);
     update();
   }
 
   function collectScores(prefix, root) {
-    return qsa(`.${prefix}-item select`, root).map((select) => Number(select.value || 0));
+    return qsa(`.${prefix}-item input[type="range"], .${prefix}-item select`, root).map((control) => Number(control.value || 0));
   }
 
   function updateResults(prefix, root, config) {
@@ -253,9 +276,9 @@
   }
 
   function resetAll(prefix, root, config) {
-    qsa(`.${prefix}-item select`, root).forEach((select) => {
-      select.value = "0";
-      select.dispatchEvent(new Event("change"));
+    qsa(`.${prefix}-item input[type="range"], .${prefix}-item select`, root).forEach((control) => {
+      control.value = "0";
+      control.dispatchEvent(new Event("input"));
     });
     const impairment = qs(`#${prefix}-impairment`, root);
     if (impairment) impairment.value = "";
@@ -287,9 +310,14 @@
     }
     exportBtn.addEventListener("click", () => exportResultsImage(prefix, root, config.title, config.fileName, exportBtn));
 
+    root.addEventListener("input", (event) => {
+      const target = event.target;
+      if (target && target.matches('input[type="range"], select')) updateResults(prefix, root, config);
+    });
+
     root.addEventListener("change", (event) => {
       const target = event.target;
-      if (target && target.matches("select")) updateResults(prefix, root, config);
+      if (target && target.matches('input[type="range"], select')) updateResults(prefix, root, config);
     });
 
     const cutoffLabel = qs(`#${prefix}-cutoff-label`, root);

--- a/docs/assets/ecr.css
+++ b/docs/assets/ecr.css
@@ -1,0 +1,329 @@
+/* ECR 中文版教育性评分页样式 */
+.ecr-app {
+  margin: 0.5rem 0 1.25rem;
+}
+
+.ecr-meta {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  margin: 0.25rem 0 1rem;
+}
+
+.ecr-hint {
+  color: color-mix(in srgb, var(--md-default-fg-color) 78%, transparent);
+  font-size: 0.86rem;
+}
+
+.ecr-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.ecr-actions .md-button {
+  border-radius: 0.55rem;
+  padding: 0.5rem 0.85rem;
+  line-height: 1.1;
+}
+
+.ecr-divider {
+  height: 1px;
+  margin: 1rem 0;
+  background: color-mix(in srgb, var(--md-default-fg-color) 12%, transparent);
+}
+
+.ecr-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 0.55rem;
+  table-layout: auto;
+}
+
+.ecr-table caption {
+  caption-side: top;
+  padding-bottom: 0.75rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.ecr-item td {
+  padding: 0.55rem 0.6rem;
+  vertical-align: middle;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 5%, transparent);
+}
+
+[data-md-color-scheme="slate"] .ecr-item td {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 12%, #1b2331);
+}
+
+.ecr-item td:first-child {
+  border-radius: 0.55rem 0 0 0.55rem;
+}
+
+.ecr-item td:last-child {
+  border-radius: 0 0.55rem 0.55rem 0;
+}
+
+.ecr-no {
+  font-weight: 700;
+  color: var(--md-primary-fg-color);
+}
+
+.ecr-dim {
+  display: none;
+  margin-left: 0.35rem;
+  padding: 0.08rem 0.35rem;
+  border-radius: 0.35rem;
+  color: color-mix(in srgb, var(--md-default-fg-color) 72%, transparent);
+  background: color-mix(in srgb, var(--md-default-fg-color) 7%, transparent);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.ecr-reverse {
+  display: none;
+  color: color-mix(in srgb, var(--md-default-fg-color) 70%, transparent);
+  font-size: 0.78rem;
+}
+
+.ecr-ctrl {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto;
+  align-items: center;
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+  --slider-offset-y: 0.13rem;
+  font-size: 0;
+}
+
+.ecr-ctrl select {
+  width: 100%;
+  min-width: 12rem;
+  padding: 0.55rem 0.7rem;
+  border: 2px solid color-mix(in srgb, var(--md-default-fg-color) 16%, transparent);
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--md-default-bg-color) 96%, transparent);
+  color: var(--md-default-fg-color);
+  font-size: 0.86rem;
+}
+
+.ecr-ctrl select:focus {
+  outline: none;
+  border-color: var(--md-primary-fg-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-primary-fg-color) 15%, transparent);
+}
+
+.ecr-ctrl input[type="range"] {
+  width: 100%;
+  min-width: 12rem;
+  touch-action: pan-y;
+  --r-track-h: 0.56rem;
+  --r-thumb-d: 1.1rem;
+  --r-thumb-offset-y: var(--slider-offset-y, 0.08rem);
+}
+
+.ecr-ctrl input[type="range"]::-webkit-slider-runnable-track {
+  height: var(--r-track-h);
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.ecr-ctrl input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  margin-top: calc((var(--r-track-h) - var(--r-thumb-d)) / 2 + var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.ecr-ctrl input[type="range"]::-moz-range-track {
+  height: var(--r-track-h);
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.ecr-ctrl input[type="range"]::-moz-range-thumb {
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  transform: translateY(var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.ecr-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.2rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 10%, transparent);
+  color: var(--md-primary-fg-color);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  transform: translateY(var(--slider-offset-y, 0));
+}
+
+.ecr-results {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.ecr-section-title {
+  font-weight: 700;
+  color: var(--md-primary-fg-color);
+}
+
+.ecr-score-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.8rem 1rem;
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 5%, transparent);
+}
+
+[data-md-color-scheme="slate"] .ecr-score-card {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 12%, #1b2331);
+}
+
+.ecr-score-label {
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+}
+
+.ecr-score-value {
+  font-size: 1.08rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecr-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 0.8rem;
+}
+
+.ecr-progress {
+  height: 0.75rem;
+  margin-top: 0.45rem;
+  overflow: hidden;
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 8%, transparent);
+}
+
+.ecr-progress > .bar {
+  width: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #4fc08d, #3fb489);
+  transition: width 0.2s ease;
+}
+
+.ecr-status {
+  font-weight: 700;
+}
+
+.ecr-status.low {
+  color: #2e7d32;
+}
+
+.ecr-status.mid {
+  color: #ef6c00;
+}
+
+.ecr-status.high {
+  color: #8e24aa;
+}
+
+@media (max-width: 760px) {
+  .ecr-meta,
+  .ecr-score-card {
+    grid-template-columns: 1fr;
+  }
+
+  .ecr-table {
+    display: block;
+    border-spacing: 0;
+    font-size: 0.88rem;
+  }
+
+  .ecr-table caption {
+    display: none;
+  }
+
+  .ecr-table colgroup,
+  .ecr-table thead {
+    display: none;
+  }
+
+  .ecr-table tbody {
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .ecr-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "no prompt"
+      "control control";
+    gap: 0.35rem 0.7rem;
+    padding: 0.75rem;
+    border-radius: 0.7rem;
+    background: color-mix(in srgb, var(--md-primary-fg-color) 5%, transparent);
+  }
+
+  [data-md-color-scheme="slate"] .ecr-item {
+    background: color-mix(in srgb, var(--md-primary-fg-color) 12%, #1b2331);
+  }
+
+  .ecr-item td {
+    display: block;
+    padding: 0;
+    background: transparent;
+  }
+
+  .ecr-item td:first-child,
+  .ecr-item td:last-child {
+    border-radius: 0;
+  }
+
+  .ecr-item td:nth-child(1) {
+    grid-area: no;
+  }
+
+  .ecr-item td:nth-child(2) {
+    grid-area: prompt;
+    font-weight: 600;
+    line-height: 1.55;
+  }
+
+  .ecr-item td:nth-child(3) {
+    grid-area: control;
+  }
+
+  .ecr-ctrl {
+    grid-template-columns: 1fr auto;
+  }
+
+  .ecr-ctrl select,
+  .ecr-ctrl input[type="range"] {
+    min-width: 0;
+  }
+
+  .ecr-badge {
+    justify-self: end;
+    align-self: center;
+  }
+}

--- a/docs/assets/ecr.js
+++ b/docs/assets/ecr.js
@@ -1,0 +1,198 @@
+/*
+ * ECR 中文版教育性评分页逻辑
+ * - 纯前端，不存储数据
+ * - 反向计分：8 - 原始分
+ */
+(function () {
+  function qs(sel, root) { return (root || document).querySelector(sel); }
+  function qsa(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+
+  function setText(root, id, text) {
+    const node = qs(`#${id}`, root);
+    if (node) node.textContent = text;
+  }
+
+  function average(values) {
+    if (!values.length) return null;
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+  }
+
+  function level(value) {
+    if (value === null) return { text: "未完成", className: "mid" };
+    if (value < 3.5) return { text: "较低", className: "low" };
+    if (value < 4.5) return { text: "中间", className: "mid" };
+    return { text: "较高", className: "high" };
+  }
+
+  function pattern(anxiety, avoidance) {
+    if (anxiety === null || avoidance === null) return "完成全部题目后显示二维参考。";
+    const highAnxiety = anxiety >= 4;
+    const highAvoidance = avoidance >= 4;
+    if (!highAnxiety && !highAvoidance) return "低焦虑、低回避：更接近安全型关系策略。";
+    if (highAnxiety && !highAvoidance) return "高焦虑、低回避：更接近焦虑-沉溺型关系策略。";
+    if (!highAnxiety && highAvoidance) return "低焦虑、高回避：更接近疏离-回避型关系策略。";
+    return "高焦虑、高回避：更接近恐惧-回避型关系策略。";
+  }
+
+  function progressWidth(value) {
+    if (value === null) return "0%";
+    return `${Math.max(0, Math.min(100, ((value - 1) / 6) * 100))}%`;
+  }
+
+  function itemNumberFromId(id) {
+    const match = String(id || "").match(/(\d+)$/);
+    return match ? match[1] : "";
+  }
+
+  function valueLabel(value) {
+    const labels = {
+      1: "非常不同意",
+      4: "中间",
+      7: "非常同意"
+    };
+    return labels[value] ? `${value} ${labels[value]}` : String(value);
+  }
+
+  function setRangeAria(input) {
+    if (!input) return;
+    if (input.dataset.empty === "true") {
+      input.setAttribute("aria-valuetext", "未作答，初始位置为 4 中间");
+    } else {
+      input.setAttribute("aria-valuetext", valueLabel(Number(input.value || 4)));
+    }
+  }
+
+  function selectToRange(select) {
+    const input = document.createElement("input");
+    input.id = select.id;
+    input.type = "range";
+    input.min = "1";
+    input.max = "7";
+    input.step = "1";
+    input.value = select.value || "4";
+    input.dataset.empty = select.value ? "false" : "true";
+    input.setAttribute("tabindex", "0");
+    select.replaceWith(input);
+    return input;
+  }
+
+  function collect(root) {
+    const rows = qsa(".ecr-item", root);
+    const scores = [];
+    const anxiety = [];
+    const avoidance = [];
+
+    rows.forEach((row) => {
+      const control = qs('input[type="range"], select', row);
+      const badge = qs(".ecr-badge", row);
+      const isEmptyRange = control && control.matches('input[type="range"]') && control.dataset.empty === "true";
+      const raw = control && control.value && !isEmptyRange ? Number(control.value) : null;
+      const reverse = row.dataset.reverse === "true";
+      const scored = raw === null ? null : reverse ? 8 - raw : raw;
+
+      if (badge) badge.textContent = scored === null ? "-" : String(scored);
+      if (control && control.matches('input[type="range"]')) setRangeAria(control);
+      if (scored !== null) {
+        scores.push(scored);
+        if (row.dataset.subscale === "anxiety") anxiety.push(scored);
+        if (row.dataset.subscale === "avoidance") avoidance.push(scored);
+      }
+    });
+
+    return {
+      count: scores.length,
+      total: rows.length,
+      anxiety: anxiety.length === 18 ? average(anxiety) : null,
+      avoidance: avoidance.length === 18 ? average(avoidance) : null
+    };
+  }
+
+  function update(root) {
+    const result = collect(root);
+    const anxietyLevel = level(result.anxiety);
+    const avoidanceLevel = level(result.avoidance);
+
+    setText(root, "ecr-completion", `${result.count}/${result.total}`);
+    setText(root, "ecr-anxiety-score", result.anxiety === null ? "-" : result.anxiety.toFixed(2));
+    setText(root, "ecr-avoidance-score", result.avoidance === null ? "-" : result.avoidance.toFixed(2));
+    setText(root, "ecr-pattern", pattern(result.anxiety, result.avoidance));
+
+    const anxietyStatus = qs("#ecr-anxiety-level", root);
+    if (anxietyStatus) {
+      anxietyStatus.textContent = anxietyLevel.text;
+      anxietyStatus.className = `ecr-status ${anxietyLevel.className}`;
+    }
+
+    const avoidanceStatus = qs("#ecr-avoidance-level", root);
+    if (avoidanceStatus) {
+      avoidanceStatus.textContent = avoidanceLevel.text;
+      avoidanceStatus.className = `ecr-status ${avoidanceLevel.className}`;
+    }
+
+    const anxietyBar = qs("#ecr-anxiety-bar", root);
+    if (anxietyBar) anxietyBar.style.width = progressWidth(result.anxiety);
+
+    const avoidanceBar = qs("#ecr-avoidance-bar", root);
+    if (avoidanceBar) avoidanceBar.style.width = progressWidth(result.avoidance);
+  }
+
+  function reset(root) {
+    qsa('.ecr-item input[type="range"], .ecr-item select', root).forEach((control) => {
+      if (control.matches('input[type="range"]')) {
+        control.value = "4";
+        control.dataset.empty = "true";
+        setRangeAria(control);
+      } else {
+        control.value = "";
+      }
+    });
+    update(root);
+  }
+
+  function bindItem(root, row) {
+    let control = qs('input[type="range"], select', row);
+    if (!control) return;
+
+    if (control.matches("select")) {
+      control = selectToRange(control);
+    }
+
+    const prompt = row.querySelector("td:nth-child(2)")?.textContent?.trim() || "";
+    const itemNumber = row.dataset.item || itemNumberFromId(control.id);
+    control.setAttribute("aria-label", `ECR 题目 ${itemNumber}: ${prompt.slice(0, 42)} - 评分 1 到 7`);
+    setRangeAria(control);
+
+    const markAnswered = () => {
+      if (control.matches('input[type="range"]')) {
+        control.dataset.empty = "false";
+      }
+      update(root);
+    };
+
+    control.addEventListener("input", markAnswered);
+    control.addEventListener("change", markAnswered);
+  }
+
+  function init() {
+    const root = document.getElementById("ecr-app");
+    if (!root || root.dataset.inited === "1") return;
+    root.dataset.inited = "1";
+
+    qsa(".ecr-item", root).forEach((row) => bindItem(root, row));
+
+    const resetBtn = qs("#ecr-reset", root);
+    if (resetBtn) resetBtn.addEventListener("click", () => reset(root));
+
+    update(root);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  if (typeof window !== "undefined" && window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(() => setTimeout(init, 0));
+  }
+})();

--- a/docs/assets/sas.css
+++ b/docs/assets/sas.css
@@ -98,13 +98,14 @@
   margin: 0;
 }
 
-/* 下拉菜单控制区 */
+/* 评分控制区 */
 .sas-ctrl {
   display: grid;
   grid-template-columns: minmax(12rem, 1fr) auto;
   align-items: center;
   column-gap: .5rem;
   row-gap: .25rem;
+  --slider-offset-y: .13rem;
   font-size: 0;
 }
 
@@ -144,6 +145,49 @@
   border-color: color-mix(in srgb, var(--md-default-fg-color) 25%, transparent);
 }
 
+.sas-ctrl input[type="range"] {
+  width: 100%;
+  min-width: 12rem;
+  touch-action: pan-y;
+  --r-track-h: .56rem;
+  --r-thumb-d: 1.1rem;
+  --r-thumb-offset-y: var(--slider-offset-y, .08rem);
+}
+
+.sas-ctrl input[type="range"]::-webkit-slider-runnable-track {
+  height: var(--r-track-h);
+  border-radius: .6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.sas-ctrl input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  margin-top: calc((var(--r-track-h) - var(--r-thumb-d)) / 2 + var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0,0,0,.12);
+}
+
+.sas-ctrl input[type="range"]::-moz-range-track {
+  height: var(--r-track-h);
+  border-radius: .6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.sas-ctrl input[type="range"]::-moz-range-thumb {
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  transform: translateY(var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0,0,0,.12);
+}
+
 /* 选项样式优化 */
 .sas-ctrl select option {
   padding: .5rem;
@@ -164,6 +208,7 @@
   width: 4.8rem;
   justify-content: center;
   font-size: .95rem;
+  transform: translateY(var(--slider-offset-y, 0));
 }
 
 /* SAS 使用分数显示 */
@@ -381,6 +426,11 @@
     font-size: .9rem;
   }
 
+  .sas-ctrl input[type="range"] {
+    width: 100%;
+    min-width: 7rem;
+  }
+
   .sas-badge {
     width: 4.8rem;
     padding: .1rem .35rem;
@@ -453,6 +503,11 @@
     width: 100%;
     min-width: 0;
     padding-right: 2.2rem;
+  }
+
+  .sas-ctrl input[type="range"] {
+    width: 100%;
+    min-width: 0;
   }
 
   .sas-badge {

--- a/docs/assets/sas.js
+++ b/docs/assets/sas.js
@@ -23,6 +23,19 @@
     return REVERSE_ITEMS.includes(itemNumber);
   }
 
+  function selectToRange(select) {
+    const input = document.createElement('input');
+    input.id = select.id;
+    input.type = 'range';
+    input.min = '1';
+    input.max = '4';
+    input.step = '1';
+    input.value = select.value || '1';
+    input.setAttribute('tabindex', '0');
+    select.replaceWith(input);
+    return input;
+  }
+
   // SAS 焦虑程度分级
   function getAnxietyLevel(standardScore) {
     if (standardScore >= 70) {
@@ -39,20 +52,23 @@
   }
 
   function bindItem(item) {
-    const select = qs('select', item);
+    let control = qs('input[type="range"], select', item);
     const badge = qs('.sas-badge', item);
-    if (!select || !badge) return;
+    if (!control || !badge) return;
 
-    // 为下拉菜单添加可访问性属性
-    const itemNumber = select.id.replace('item', '');
+    if (control.matches('select')) {
+      control = selectToRange(control);
+    }
+
+    // 为评分滑块添加可访问性属性
+    const itemNumber = parseInt(control.id.replace('item', ''), 10);
     const questionText = item.querySelector('td:nth-child(2)')?.textContent?.trim() || '';
-    if (!select.hasAttribute('aria-label')) {
-      select.setAttribute('aria-label', `题目 ${itemNumber}: ${questionText.substring(0, 30)}... - 评分 1 到 4`);
-      select.setAttribute('tabindex', '0');
+    if (!control.hasAttribute('aria-label')) {
+      control.setAttribute('aria-label', `题目 ${itemNumber}: ${questionText.substring(0, 30)}... - 评分 1 到 4`);
     }
 
     const update = () => {
-      const rawValue = Number(select.value || 1);
+      const rawValue = Number(control.value || 1);
       const actualValue = isReverseItem(itemNumber) ? (5 - rawValue) : rawValue;
       badge.textContent = actualValue;
 
@@ -66,7 +82,8 @@
       }
     };
 
-    select.addEventListener('change', update);
+    control.addEventListener('input', update);
+    control.addEventListener('change', update);
     update();
   }
 
@@ -171,9 +188,9 @@
 
   function collectScores(root) {
     const scores = [];
-    qsa('.sas-item select', root).forEach((select) => {
-      const itemNumber = parseInt(select.id.replace('item', ''));
-      const rawValue = Number(select.value || 1);
+    qsa('.sas-item input[type="range"], .sas-item select', root).forEach((control) => {
+      const itemNumber = parseInt(control.id.replace('item', ''), 10);
+      const rawValue = Number(control.value || 1);
       const actualValue = isReverseItem(itemNumber) ? (5 - rawValue) : rawValue;
       if (!Number.isNaN(actualValue)) scores.push(actualValue);
     });
@@ -278,9 +295,9 @@
       let score = 0;
 
       scale.items.forEach(itemNum => {
-        const select = qs(`#item${itemNum}`, root);
-        if (select) {
-          const rawValue = Number(select.value || 1);
+        const control = qs(`#item${itemNum}`, root);
+        if (control) {
+          const rawValue = Number(control.value || 1);
           const actualValue = isReverseItem(itemNum) ? (5 - rawValue) : rawValue;
           score += actualValue;
         }
@@ -298,9 +315,9 @@
   }
 
   function resetAll(root) {
-    qsa('.sas-item select', root).forEach((select) => {
-      select.value = '1'; // 重置为最低分
-      select.dispatchEvent(new Event('change'));
+    qsa('.sas-item input[type="range"], .sas-item select', root).forEach((control) => {
+      control.value = '1'; // 重置为最低分
+      control.dispatchEvent(new Event('input'));
     });
     updateResults(root);
   }
@@ -327,9 +344,13 @@
     exportBtn.addEventListener('click', () => exportResultsImage(root, exportBtn));
 
     // 实时更新结果
+    root.addEventListener('input', (e) => {
+      const t = e.target;
+      if (t && t.matches('input[type="range"], select')) updateResults(root);
+    });
     root.addEventListener('change', (e) => {
       const t = e.target;
-      if (t && t.matches('select')) updateResults(root);
+      if (t && t.matches('input[type="range"], select')) updateResults(root);
     });
 
     // 初始计算一次

--- a/docs/assets/sds.css
+++ b/docs/assets/sds.css
@@ -98,13 +98,14 @@
   margin: 0;
 }
 
-/* 下拉菜单控制区 */
+/* 评分控制区 */
 .sds-ctrl {
   display: grid;
   grid-template-columns: minmax(12rem, 1fr) auto;
   align-items: center;
   column-gap: .5rem;
   row-gap: .25rem;
+  --slider-offset-y: .13rem;
   font-size: 0;
 }
 
@@ -144,6 +145,49 @@
   border-color: color-mix(in srgb, var(--md-default-fg-color) 25%, transparent);
 }
 
+.sds-ctrl input[type="range"] {
+  width: 100%;
+  min-width: 12rem;
+  touch-action: pan-y;
+  --r-track-h: .56rem;
+  --r-thumb-d: 1.1rem;
+  --r-thumb-offset-y: var(--slider-offset-y, .08rem);
+}
+
+.sds-ctrl input[type="range"]::-webkit-slider-runnable-track {
+  height: var(--r-track-h);
+  border-radius: .6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.sds-ctrl input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  margin-top: calc((var(--r-track-h) - var(--r-thumb-d)) / 2 + var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0,0,0,.12);
+}
+
+.sds-ctrl input[type="range"]::-moz-range-track {
+  height: var(--r-track-h);
+  border-radius: .6rem;
+  background: color-mix(in srgb, var(--md-default-fg-color) 18%, transparent);
+}
+
+.sds-ctrl input[type="range"]::-moz-range-thumb {
+  width: var(--r-thumb-d);
+  height: var(--r-thumb-d);
+  border: 2px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 90%, #fff);
+  transform: translateY(var(--r-thumb-offset-y));
+  box-shadow: 0 1px 2px rgba(0,0,0,.12);
+}
+
 /* 选项样式优化 */
 .sds-ctrl select option {
   padding: .5rem;
@@ -164,6 +208,7 @@
   width: 4.8rem;
   justify-content: center;
   font-size: .95rem;
+  transform: translateY(var(--slider-offset-y, 0));
 }
 
 /* SDS 使用分数显示 */
@@ -329,6 +374,11 @@
     font-size: .9rem;
   }
 
+  .sds-ctrl input[type="range"] {
+    width: 100%;
+    min-width: 7rem;
+  }
+
   .sds-badge {
     width: 4.8rem;
     padding: .1rem .35rem;
@@ -399,6 +449,11 @@
     width: 100%;
     min-width: 0;
     padding-right: 2.2rem;
+  }
+
+  .sds-ctrl input[type="range"] {
+    width: 100%;
+    min-width: 0;
   }
 
   .sds-badge {

--- a/docs/assets/sds.js
+++ b/docs/assets/sds.js
@@ -23,6 +23,19 @@
     return REVERSE_ITEMS.includes(itemNumber);
   }
 
+  function selectToRange(select) {
+    const input = document.createElement('input');
+    input.id = select.id;
+    input.type = 'range';
+    input.min = '1';
+    input.max = '4';
+    input.step = '1';
+    input.value = select.value || '1';
+    input.setAttribute('tabindex', '0');
+    select.replaceWith(input);
+    return input;
+  }
+
   // SDS 严重程度分级
   function getSeverityLevel(standardScore) {
     if (standardScore >= 73) {
@@ -37,20 +50,23 @@
   }
 
   function bindItem(item) {
-    const select = qs('select', item);
+    let control = qs('input[type="range"], select', item);
     const badge = qs('.sds-badge', item);
-    if (!select || !badge) return;
+    if (!control || !badge) return;
 
-    // 为下拉菜单添加可访问性属性
-    const itemNumber = select.id.replace('item', '');
+    if (control.matches('select')) {
+      control = selectToRange(control);
+    }
+
+    // 为评分滑块添加可访问性属性
+    const itemNumber = parseInt(control.id.replace('item', ''), 10);
     const questionText = item.querySelector('td:nth-child(2)')?.textContent?.trim() || '';
-    if (!select.hasAttribute('aria-label')) {
-      select.setAttribute('aria-label', `题目 ${itemNumber}: ${questionText.substring(0, 30)}... - 评分 1 到 4`);
-      select.setAttribute('tabindex', '0');
+    if (!control.hasAttribute('aria-label')) {
+      control.setAttribute('aria-label', `题目 ${itemNumber}: ${questionText.substring(0, 30)}... - 评分 1 到 4`);
     }
 
     const update = () => {
-      const rawValue = Number(select.value || 1);
+      const rawValue = Number(control.value || 1);
       const actualValue = isReverseItem(itemNumber) ? (5 - rawValue) : rawValue;
       badge.textContent = actualValue;
 
@@ -64,7 +80,8 @@
       }
     };
 
-    select.addEventListener('change', update);
+    control.addEventListener('input', update);
+    control.addEventListener('change', update);
     update();
   }
 
@@ -169,9 +186,9 @@
 
   function collectScores(root) {
     const scores = [];
-    qsa('.sds-item select', root).forEach((select) => {
-      const itemNumber = parseInt(select.id.replace('item', ''));
-      const rawValue = Number(select.value || 1);
+    qsa('.sds-item input[type="range"], .sds-item select', root).forEach((control) => {
+      const itemNumber = parseInt(control.id.replace('item', ''), 10);
+      const rawValue = Number(control.value || 1);
       const actualValue = isReverseItem(itemNumber) ? (5 - rawValue) : rawValue;
       if (!Number.isNaN(actualValue)) scores.push(actualValue);
     });
@@ -244,9 +261,9 @@
   }
 
   function resetAll(root) {
-    qsa('.sds-item select', root).forEach((select) => {
-      select.value = '1'; // 重置为最低分
-      select.dispatchEvent(new Event('change'));
+    qsa('.sds-item input[type="range"], .sds-item select', root).forEach((control) => {
+      control.value = '1'; // 重置为最低分
+      control.dispatchEvent(new Event('input'));
     });
     updateResults(root);
   }
@@ -273,9 +290,13 @@
     exportBtn.addEventListener('click', () => exportResultsImage(root, exportBtn));
 
     // 实时更新结果
+    root.addEventListener('input', (e) => {
+      const t = e.target;
+      if (t && t.matches('input[type="range"], select')) updateResults(root);
+    });
     root.addEventListener('change', (e) => {
       const t = e.target;
-      if (t && t.matches('select')) updateResults(root);
+      if (t && t.matches('input[type="range"], select')) updateResults(root);
     });
 
     // 初始计算一次

--- a/docs/entries/Experiences-in-Close-Relationships-ECR-Chinese.md
+++ b/docs/entries/Experiences-in-Close-Relationships-ECR-Chinese.md
@@ -1,0 +1,206 @@
+---
+title: 亲密关系经历量表中文版（Experiences in Close Relationships, ECR）
+tags:
+    - scale:ECR
+    - scale:评估量表
+    - theory:成人依恋
+    - theory:依恋理论
+
+topic: 理论与分类
+synonyms:
+  - 亲密关系经历量表
+  - ECR
+  - ECR中文版
+  - Experiences in Close Relationships
+  - 成人依恋量表
+  - 依恋焦虑量表
+  - 依恋回避量表
+
+description: 亲密关系经历量表中文版（ECR）是成人依恋研究中的常用自评工具，包含依恋焦虑与依恋回避两个维度，适合教育性自我观察与研究资料整理。
+updated: YYYY-MM-DD
+search:
+  boost: 1.5
+hide:
+  - toc
+
+extra_css:
+  - assets/ecr.css
+
+extra_javascript:
+  - assets/ecr.js
+
+comments: true
+---
+
+# 亲密关系经历量表中文版（Experiences in Close Relationships, ECR）
+
+!!! danger "重要声明"
+本页面仅用于教育、自我观察与资料整理，**不构成心理诊断、伴侣评判或治疗建议**。ECR 描述的是亲密关系中的依恋焦虑与依恋回避倾向，不应用来给自己、伴侣或系统成员贴固定标签。
+
+!!! note "版本说明"
+下方在线题项为基于 ECR 中文版结构的**教育性改写版**，用于帮助理解计分方式与维度含义。正式研究、论文写作或临床评估请回到李同归、加藤和生（2006）发表的中文版原文与授权要求。
+
+## 概述
+
+**亲密关系经历量表（Experiences in Close Relationships Inventory, ECR）** 由 Brennan、Clark 与 Shaver 在整合多种成人依恋自评量表后编制，常被用作成人浪漫关系依恋研究中的标准化工具。中文版由李同归、加藤和生修订，发表于《心理学报》2006 年第 38 卷第 3 期。
+
+ECR 采用两个连续维度描述成人依恋：
+
+- **依恋焦虑（Attachment Anxiety）**：担心被拒绝、被抛弃、对方不够在乎自己，常表现为反复确认与关系不安。
+- **依恋回避（Attachment Avoidance）**：对亲密、依赖、暴露脆弱或寻求支持感到不自在，常表现为拉开距离或降低情感表达。
+
+低焦虑、低回避通常更接近[安全型成人依恋](Adult-Attachment.md)；高焦虑或高回避则提示个体在亲密关系压力下可能更常使用不同的不安全依恋策略。
+
+## 评分说明
+
+!!! tip "使用说明"
+
+    - 请依据你在**恋爱或亲密关系中的一般体验**作答，而不是只看某一次冲突。
+    - 每题采用 `1-7` 分：`1 = 非常不同意`，`7 = 非常同意`。
+    - 标注“反向计分”的题目会自动换算为 `8 - 原始分`。
+    - 两个维度各 18 题，页面显示的是各维度平均分，范围 `1-7`。
+
+## 在线评估
+
+<div id="ecr-app" class="ecr-app">
+
+<div class="ecr-meta">
+  <div class="ecr-hint">评分范围 1-7（1=非常不同意，7=非常同意）· 结果仅在本地浏览器即时计算</div>
+  <div class="ecr-actions">
+    <button id="ecr-reset" class="md-button" type="button">重置</button>
+  </div>
+</div>
+
+<div class="ecr-divider"></div>
+
+<table class="ecr-table">
+  <caption>ECR 中文版教育性题项与评分</caption>
+  <colgroup>
+    <col style="width:3rem">
+    <col>
+    <col style="width:auto; min-width:17rem">
+  </colgroup>
+  <thead>
+    <tr><th scope="col">#</th><th scope="col">关系体验描述</th><th scope="col">评分</th></tr>
+  </thead>
+  <tbody>
+    <tr class="ecr-item" data-item="1" data-subscale="avoidance"><td class="ecr-no">1</td><td>总的来说，我不喜欢让恋人知道自己内心深处的感觉。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item1"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item1">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="2" data-subscale="anxiety"><td class="ecr-no">2</td><td>我担心我会被抛弃。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item2"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item2">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="3" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">3</td><td>我觉得跟恋人亲近是一件惬意的事情。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item3"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item3">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="4" data-subscale="anxiety"><td class="ecr-no">4</td><td>我很担心我的恋爱关系。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item4"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item4">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="5" data-subscale="avoidance"><td class="ecr-no">5</td><td>当恋人开始要跟我亲近时，我发现自己在退缩。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item5"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item5">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="6" data-subscale="anxiety"><td class="ecr-no">6</td><td>我担心恋人不会像我关心他／她那样关心我。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item6"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item6">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="7" data-subscale="avoidance"><td class="ecr-no">7</td><td>当恋人希望跟我非常亲近时，我会觉得不自在。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item7"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item7">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="8" data-subscale="anxiety"><td class="ecr-no">8</td><td>我有点担心会失去恋人。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item8"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item8">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="9" data-subscale="avoidance"><td class="ecr-no">9</td><td>我觉得对恋人开诚布公，不是一件很舒服的事情。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item9"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item9">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="10" data-subscale="anxiety"><td class="ecr-no">10</td><td>我常常希望恋人对我的感情和我对恋人的感情一样强烈。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item10"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item10">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="11" data-subscale="avoidance"><td class="ecr-no">11</td><td>我想与恋人亲近，但我又总是会退缩不前。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item11"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item11">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="12" data-subscale="anxiety"><td class="ecr-no">12</td><td>我常常想与恋人形影不离，但有时这样会把恋人吓跑。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item12"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item12">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="13" data-subscale="avoidance"><td class="ecr-no">13</td><td>当恋人跟我过分亲密的时候，我会感到内心紧张。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item13"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item13">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="14" data-subscale="anxiety"><td class="ecr-no">14</td><td>我担心一个人独处。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item14"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item14">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="15" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">15</td><td>我愿意把内心的想法和感觉告诉恋人，我觉得这是一件自在的事情。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item15"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item15">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="16" data-subscale="anxiety"><td class="ecr-no">16</td><td>我想跟恋人非常亲密的愿望，有时会把恋人吓跑。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item16"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item16">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="17" data-subscale="avoidance"><td class="ecr-no">17</td><td>我试图避免与恋人变得太亲近。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item17"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item17">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="18" data-subscale="anxiety"><td class="ecr-no">18</td><td>我需要恋人一再地保证他／她是爱我的。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item18"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item18">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="19" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">19</td><td>我觉得我比较容易与恋人亲近。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item19"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item19">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="20" data-subscale="anxiety"><td class="ecr-no">20</td><td>我觉得自己在要求恋人更多地表现出他／她的感觉，以及对恋爱关系的投入程度。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item20"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item20">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="21" data-subscale="avoidance"><td class="ecr-no">21</td><td>我发现让我依赖恋人，是一件困难的事情。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item21"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item21">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="22" data-subscale="anxiety" data-reverse="true"><td class="ecr-no">22</td><td>我并不是常常担心被恋人抛弃。<span class="ecr-dim">焦虑</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item22"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item22">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="23" data-subscale="avoidance"><td class="ecr-no">23</td><td>我倾向于不跟恋人过分亲密。<span class="ecr-dim">回避</span></td><td><div class="ecr-ctrl"><select id="ecr-item23"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item23">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="24" data-subscale="anxiety"><td class="ecr-no">24</td><td>如果我无法得到恋人的注意和关心，我会心烦意乱或者生气。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item24"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item24">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="25" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">25</td><td>我跟恋人什么事情都讲。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item25"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item25">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="26" data-subscale="anxiety"><td class="ecr-no">26</td><td>我发现恋人并不愿意像我所想的那样跟我亲近。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item26"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item26">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="27" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">27</td><td>我经常与恋人讨论我所遇到的问题以及我关心的事情。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item27"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item27">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="28" data-subscale="anxiety"><td class="ecr-no">28</td><td>如果我还没有恋人的话，我会感到有点焦虑和不安。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item28"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item28">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="29" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">29</td><td>我觉得依赖恋人是很自在的事情。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item29"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item29">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="30" data-subscale="anxiety"><td class="ecr-no">30</td><td>如果恋人不能像我所希望的那样在我身边，我会感到灰心丧气。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item30"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item30">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="31" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">31</td><td>我并不在意从恋人那里寻找安慰、听取劝告和得到帮助。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item31"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item31">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="32" data-subscale="anxiety"><td class="ecr-no">32</td><td>如果在我需要的时候，恋人却不在我身边，我会感到沮丧。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item32"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item32">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="33" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">33</td><td>在需要的时候，我向恋人求助是很有用的。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item33"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item33">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="34" data-subscale="anxiety"><td class="ecr-no">34</td><td>当恋人不赞同我时，我觉得确实是我不好。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item34"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item34">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="35" data-subscale="avoidance" data-reverse="true"><td class="ecr-no">35</td><td>我会在很多事情上向恋人求助，包括寻求安慰和得到承诺。<span class="ecr-dim">回避</span> <span class="ecr-reverse">反向计分</span></td><td><div class="ecr-ctrl"><select id="ecr-item35"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item35">-</output></div></td></tr>
+    <tr class="ecr-item" data-item="36" data-subscale="anxiety"><td class="ecr-no">36</td><td>当恋人不花时间和我在一起时，我会感到怨恨。<span class="ecr-dim">焦虑</span></td><td><div class="ecr-ctrl"><select id="ecr-item36"><option value="">请选择</option><option value="1">1 非常不同意</option><option value="2">2</option><option value="3">3</option><option value="4">4 中间</option><option value="5">5</option><option value="6">6</option><option value="7">7 非常同意</option></select><output class="ecr-badge" for="ecr-item36">-</output></div></td></tr>
+  </tbody>
+</table>
+
+<div class="ecr-divider"></div>
+
+<div id="ecr-results" class="ecr-results">
+  <div class="ecr-section-title">评估结果</div>
+
+  <div class="ecr-grid">
+    <div class="ecr-score-card">
+      <div>
+        <div class="ecr-score-label">依恋焦虑均分</div>
+        <div class="ecr-hint">18 题平均，范围 1-7</div>
+        <div class="ecr-progress" aria-label="依恋焦虑均分可视化"><div id="ecr-anxiety-bar" class="bar"></div></div>
+      </div>
+      <div><div class="ecr-score-value" id="ecr-anxiety-score">-</div><div id="ecr-anxiety-level" class="ecr-status mid">未完成</div></div>
+    </div>
+    <div class="ecr-score-card">
+      <div>
+        <div class="ecr-score-label">依恋回避均分</div>
+        <div class="ecr-hint">18 题平均，范围 1-7</div>
+        <div class="ecr-progress" aria-label="依恋回避均分可视化"><div id="ecr-avoidance-bar" class="bar"></div></div>
+      </div>
+      <div><div class="ecr-score-value" id="ecr-avoidance-score">-</div><div id="ecr-avoidance-level" class="ecr-status mid">未完成</div></div>
+    </div>
+  </div>
+
+  <div class="ecr-score-card">
+    <div>
+      <div class="ecr-score-label">二维参考</div>
+      <div class="ecr-hint" id="ecr-pattern">完成全部题目后显示二维参考。</div>
+    </div>
+    <div class="ecr-score-value" id="ecr-completion">0/36</div>
+  </div>
+</div>
+
+</div>
+
+## 解释框架
+
+ECR 的重点不是把人固定分型，而是观察亲密关系压力下的两条策略轴线。为了便于理解，可以把两个维度粗略放入四象限：
+
+| 依恋焦虑 | 依恋回避 | 参考模式    | 常见关系策略                                     |
+| -------- | -------- | ----------- | ------------------------------------------------ |
+| 低       | 低       | 安全型      | 能在亲近、独立、求助与边界之间较灵活切换         |
+| 高       | 低       | 焦虑-沉溺型 | 更担心被抛弃，常需要确认与稳定回应               |
+| 低       | 高       | 疏离-回避型 | 更重视独立，亲密或依赖增加时可能拉开距离         |
+| 高       | 高       | 恐惧-回避型 | 同时渴望亲密又害怕亲密，可能在靠近和撤离之间摆荡 |
+
+!!! warning "不要把分数当成关系判决"
+ECR 分数会受当前关系状态、冲突频率、创伤触发、文化表达方式、关系对象和作答时情绪影响。它适合帮助发现“我在关系压力下如何保护自己”，不适合用来证明某个人“有问题”。
+
+## 量表信息
+
+- **原量表**：Experiences in Close Relationships Inventory（ECR）
+- **原始结构**：36 题，依恋焦虑 18 题，依恋回避 18 题
+- **评分方式**：1-7 分自评，部分题目反向计分后分别计算两个维度均分
+- **中文版研究样本**：371 名中国大学生接受测试，其中 231 名有恋爱经历者进入主要分析；59 名被试在 4 周后重测
+- **信度摘要**：李同归、加藤和生（2006）报告中文版依恋回避与依恋焦虑的内部一致性系数分别为 0.82、0.77，重测信度分别为 0.71、0.72
+- **效度摘要**：研究报告 ECR 中文版与 RQ、自尊、他人观、STAI、SAD 及恋人评定结果呈现符合理论预期的相关模式
+
+## 在多意识体与创伤语境中的使用
+
+在 DID、OSDD 或其他具有明显部分化体验的人身上，ECR 的作答可能受到“谁在前台”“正在回忆哪段关系”“哪个成员负责亲密/防御”影响。因此建议：
+
+- 如果不同成员的关系策略差异明显，可分别记录“谁在作答”和当时状态；
+- 把结果作为[成人依恋](Adult-Attachment.md)与[依恋创伤](Attachment-Trauma.md)讨论的入口，而不是系统整体的固定标签；
+- 若作答过程引发强烈情绪、解离或关系冲动，先使用[接地](Grounding.md)与稳定策略，再继续整理关系议题；
+- 治疗中应由专业人员结合访谈、关系史、创伤史和功能状态综合理解。
+
+## 相关条目
+
+- [成人依恋（Adult Attachment）](Adult-Attachment.md)
+- [依恋理论（Attachment Theory）](Attachment-Theory.md)
+- [依恋创伤（Attachment Trauma）](Attachment-Trauma.md)
+- [情绪调节（Emotion Regulation）](Emotion-Regulation.md)
+- [移情与反移情（Transference and Countertransference）](Transference-Countertransference.md)
+
+## 参考与延伸阅读
+
+1. Brennan, K. A., Clark, C. L., & Shaver, P. R. (1998). Self-report measurement of adult attachment: An integrative overview. In J. A. Simpson & W. S. Rholes (Eds.), _Attachment Theory and Close Relationships_ (pp. 46-76). Guilford Press.
+2. 李同归, & 加藤和生. (2006). 成人依恋的测量: 亲密关系经历量表（ECR）中文版. _心理学报_, 38(3), 399-406.
+3. Bartholomew, K., & Horowitz, L. M. (1991). Attachment styles among young adults: A test of a four-category model. _Journal of Personality and Social Psychology_, 61(2), 226-244.
+4. Fraley, R. C., Waller, N. G., & Brennan, K. A. (2000). An item response theory analysis of self-report measures of adult attachment. _Journal of Personality and Social Psychology_, 78(2), 350-365.

--- a/docs/guides/Theory-Classification-Guide.md
+++ b/docs/guides/Theory-Classification-Guide.md
@@ -86,6 +86,7 @@ search:
 
 - 🧸 [依恋理论](../entries/Attachment-Theory.md)：依恋类型的形成与影响。
 - 🔗 [成人依恋（Adult Attachment）](../entries/Adult-Attachment.md)：解释成年亲密关系中的依恋焦虑、依恋回避与四种常见关系模式。
+- 📏 [亲密关系经历量表中文版（ECR）](../entries/Experiences-in-Close-Relationships-ECR-Chinese.md)：成人依恋二维测量工具，帮助观察依恋焦虑与依恋回避在亲密关系中的表现。
 - 🩹 [依恋创伤（Attachment Trauma）](../entries/Attachment-Trauma.md)：理解照护失配、背叛与忽视如何塑造内部工作模型、关系触发与修复路径。
 - 🪢 [社会认知理论](../entries/Social-Cognitive-Theory.md)：观察学习与环境交互。
 - 💬 [移情与反移情](../entries/Transference-Countertransference.md)：治疗情境中的情感投射与反馈。

--- a/docs/guides/Theory-Classification-index.md
+++ b/docs/guides/Theory-Classification-index.md
@@ -20,6 +20,7 @@ hide:
 ## 词条一览
 
 - [成人依恋（Adult Attachment）](../entries/Adult-Attachment.md) — *2026-05-12*
+- [亲密关系经历量表中文版（Experiences in Close Relationships, ECR）](../entries/Experiences-in-Close-Relationships-ECR-Chinese.md) — *YYYY-MM-DD*
 - [依恋理论（Attachment Theory）](../entries/Attachment-Theory.md) — *2026-03-27*
 - [注意与觉察（Attention & Awareness）](../entries/Attention-Awareness.md) — *2026-03-27*
 - [行为主义心理学（Behaviorism）](../entries/Behaviorism.md) — *2026-03-27*


### PR DESCRIPTION
## 变更内容

- 新增 `亲密关系经历量表中文版（ECR）` 词条，包含教育性说明、在线评分表、二维解释框架、相关条目与参考文献。
- 新增 ECR 页面专用前端资源 `docs/assets/ecr.css` 和 `docs/assets/ecr.js`，用于本地即时评分、反向计分、完成度统计与结果展示。
- 同步更新理论与分类 Guide、分类索引和 `docs/SUMMARY.md`。

## 已发布量表页面控件变更

- `docs/assets/brief-scales.css` / `docs/assets/brief-scales.js`：将简短量表评分控件从 `select` 增强为 `range` 滑块，并保留既有分数采集、重置、结果更新和导出逻辑。
- `docs/assets/sas.css` / `docs/assets/sas.js`：将 SAS 评分控件从 `select` 增强为 `range` 滑块，保留反向计分、标准分、等级与子量表计算逻辑。
- `docs/assets/sds.css` / `docs/assets/sds.js`：将 SDS 评分控件从 `select` 增强为 `range` 滑块，保留反向计分、标准分和严重程度判断逻辑。

## 影响

该 PR 增加成人依恋测量相关资料，并改善多个量表页面在移动端和重复作答场景下的评分体验。页面仍明确标注教育性用途，不构成诊断或治疗建议。

## 验证

- `make check` 通过
- `make build` 通过
- 已检查 ECR 表格源码：36 个题目行、36 个 `.ecr-badge`、36 个 `</output>`，未发现游离的 `</tr></output>` 或重复 `</output>`

构建输出中仍包含仓库既有 MkDocs/链接 warning，按当前处理要求未纳入本 PR 修复范围。