### PR TITLE
fix: ECR badge 显示原始选择值而非换算分

### DIFF
--- a/docs/assets/ecr.js
+++ b/docs/assets/ecr.js
@@ -90,7 +90,7 @@
       const reverse = row.dataset.reverse === "true";
       const scored = raw === null ? null : reverse ? 8 - raw : raw;
 
-      if (badge) badge.textContent = scored === null ? "-" : String(scored);
+      if (badge) badge.textContent = raw === null ? "-" : String(raw);
       if (control && control.matches('input[type="range"]')) setRangeAria(control);
       if (scored !== null) {
         scores.push(scored);


### PR DESCRIPTION
## 变更说明

反向计分题中，用户选择某值后 badge 显示的是换算后的分值（如选1显示7），与做题逻辑不符。

将 badge 改为显示原始选择值，换算逻辑仅用于内部计分，不影响结果计算。