### PR TITLE
docs: AGENTS.md 新增 main 分支保护与 PR 工作流规范

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,13 @@
 │  ├─ 小步提交 + 回滚指引
 │  └─ PR 说明自动化方法(正则/脚本/范围)
 │
-└─ 提交前检查
-   ├─ make check
-   ├─ make build
-   └─ uv run mkdocs build --strict(额外严格检查,可选)
+└─ 提交与 PR(禁止直接推 main)
+   ├─ 新建功能分支(勿在 main 上改)
+   ├─ make check + make build
+   ├─ commit(Conventional Commits,小步提交)
+   ├─ push 功能分支
+   ├─ gh pr create
+   └─ 等待所有者审核合并(勿自行合并 main)
 ```
 
 ---
@@ -125,6 +128,56 @@ type 必须是:
 | ❌ 无迹可查 | 禁止无法验证来源的批量修改 |
 | ❌ 破坏索引 | 禁止破坏导航/引用完整性 |
 | ⚠️ 大规模重构 | 必须附回滚指引 |
+
+### 2.5 分支与 PR 工作流(强制)
+
+!!! danger "main 分支受 Ruleset 保护,禁止直接推送"
+
+    仓库默认分支 `main` 已配置 GitHub Ruleset(`Protect default branch`,id `18161454`):
+
+    - ❌ 禁止删除 `main`
+    - ❌ 禁止强推(`git push --force`)`main`
+    - ✅ 必须通过 Pull Request 合并
+    - ✅ PR 对话需解决(`required_review_thread_resolution`)
+    - ⚠️ 管理员亦不可绕过(`current_user_can_bypass: never`)
+
+    **所有改动必须走 PR 流程,不得直接推送 main。**
+
+#### 标准流程
+
+```text
+1. 新建功能分支(勿在 main 上改)
+   git checkout -b feat/<简短描述>
+
+2. 完成修改(遵循 §2.1-§2.4)
+
+3. 本地检查
+   make check
+   make build
+
+4. 小步提交(Conventional Commits)
+   git add <相关文件>
+   git commit -m "feat: 新增 Grounding 词条"
+
+5. 推送功能分支
+   git push -u origin feat/<简短描述>
+
+6. 创建 Pull Request
+   gh pr create --title "feat: 新增 Grounding 词条" \
+                --body "变更说明..."
+
+7. 等待所有者审核合并(勿自行合并 main)
+```
+
+#### 禁止事项
+
+| 操作 | 规范 |
+|------|------|
+| ❌ 直接推送 main | `git push origin main` 会被服务端拒绝 |
+| ❌ 强推 main | `git push --force origin main` 会被服务端拒绝 |
+| ❌ 删除 main | 删除分支会被服务端拒绝 |
+| ❌ 自行合并 PR | 由仓库所有者审核合并 |
+| ✅ 新建分支 → PR | 唯一合法的改动路径 |
 
 ---
 


### PR DESCRIPTION
## 变更内容

在 AGENTS.md 中固化上一轮为仓库配置的 main 分支保护规则，使 AI 代理强制遵守 PR 工作流。

### 修改点

1. **决策树末段**（§快速开始）：将"提交前检查"替换为完整的"提交与 PR"流程节点，明确禁止直接推 main。
2. **新增 §2.5 分支与 PR 工作流（强制）**：
   - 记录已生效的 GitHub Ruleset（id `18161454`，`Protect default branch`）
   - 列明四条服务端强制规则：禁止删除 main、禁止强推、必须经 PR 合并、PR 对话需解决
   - 标注 `current_user_can_bypass: never`（管理员亦不可绕过）
   - 给出标准 7 步流程：新建分支 → 修改 → `make check` + `make build` → commit → push → `gh pr create` → 等待审核
   - 列出禁止事项表

## 背景

仓库已通过 GitHub API 创建 Ruleset `18161454`，对 `refs/heads/main` 启用：
- `deletion`（禁止删除）
- `non_fast_forward`（禁止强推）
- `pull_request`（required_approving_review_count=0，required_review_thread_resolution=true）

本次将上述事实写入 AGENTS.md，让 Codex/Claude/Copilot 等代理在执行任务时知晓约束并主动走 PR 流程。

## 验证

- [x] `make check` 通过（退出码 0）
- [x] 构建成功（既有 WARNING/INFO 为历史问题，与本次改动无关）
- [x] 仅修改 AGENTS.md，未触碰 docs/entries/、tools/、配置文件

## 回滚

如需撤销本文档变更， revert 此 commit 即可。Ruleset 本身不受影响，如需一并删除见上一轮交付的回滚命令。