### PR TITLE
feat: 新增知识库干净版导出工具

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ $RECYCLE.BIN/
 tmp/
 temp/
 
+# === 知识库导出 ===
+dist/knowledge/
+
 # === AI 词典生成工具的临时文件 ===
 data/analysis_report.json
 data/batches/

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,11 @@ PDF_ENGINE ?= tectonic
 CJK_FONT ?= Microsoft YaHei
 PDF_OUTPUT ?= releases/Multiple_Personality_System_wiki.pdf
 PDF_EXTRA_ARGS ?=
+KNOWLEDGE_INPUT ?= docs/entries
+KNOWLEDGE_OUTPUT ?= dist/knowledge/entries
 STATUS_TOP ?= 10
 
-.PHONY: help status links tags frontmatter build serve pdf fix lint check all
+.PHONY: help status links tags frontmatter build serve pdf fix lint check all knowledge
 
 help:
 	@printf '%s\n' \
@@ -25,6 +27,7 @@ help:
 		'  make frontmatter  检查词条 Frontmatter' \
 		'  make build        构建 MkDocs 站点' \
 		'  make serve        启动本地预览服务' \
+		'  make knowledge    导出干净知识库（供全文检索/qq-maid-bot 使用）' \
 		'  make pdf          导出 PDF' \
 		'  make fix          修复 docs/entries/ 下的 Markdown 格式' \
 		'  make lint         运行 markdownlint' \
@@ -38,6 +41,8 @@ help:
 		'  STATUS_TOP=10' \
 		'  PDF_ENGINE=tectonic' \
 		'  CJK_FONT=Microsoft YaHei' \
+		'  KNOWLEDGE_INPUT=docs/entries' \
+		'  KNOWLEDGE_OUTPUT=dist/knowledge/entries' \
 		'  PDF_OUTPUT=releases/Multiple_Personality_System_wiki.pdf' \
 		'  PDF_EXTRA_ARGS=...' \
 		'' \
@@ -45,6 +50,8 @@ help:
 		'  make status' \
 		'  make status STATUS_DIRS="docs/entries"' \
 		'  make status STATUS_TOP=20' \
+		'  make knowledge' \
+		'  make knowledge KNOWLEDGE_OUTPUT=/custom/path' \
 		'  make check' \
 		'  make pdf PDF_ENGINE=xelatex CJK_FONT="Noto Serif CJK SC"' \
 		'  make pdf PDF_OUTPUT=dist/wiki.pdf PDF_EXTRA_ARGS='\''--include-tags "guide:入门指南"'\'''
@@ -78,6 +85,9 @@ build:
 
 serve:
 	$(UV) run mkdocs serve
+
+knowledge:
+	$(UV) run $(PYTHON) tools/export_knowledge.py --input "$(KNOWLEDGE_INPUT)" --output "$(KNOWLEDGE_OUTPUT)"
 
 pdf:
 	@set -- $(UV) run $(PYTHON) tools/pdf_export/export_to_pdf.py --pdf-engine "$(PDF_ENGINE)" --cjk-font "$(CJK_FONT)"; \

--- a/docs/dev/Tools-Index.md
+++ b/docs/dev/Tools-Index.md
@@ -67,6 +67,7 @@ bash tools/run_local_updates.sh --help
 | 提交到 IndexNow | `python3 tools/submit_to_indexnow.py --recent 50` |
 | 本地预览 | `make serve` |
 | 构建静态站点 | `make build` |
+| 导出干净知识库 | `make knowledge` |
 
 ## 📦 核心自动化工具(CI 集成)
 
@@ -130,6 +131,7 @@ bash tools/run_local_updates.sh --help
 | 工具 | 功能 | 使用频率 |
 |------|------|---------|
 | **pdf_export/** | Pandoc 驱动的整站 PDF 导出 | 📄 归档时 |
+| **export_knowledge.py** | 将 `docs/entries/` 词条导出为干净 Markdown，供全文检索引擎（如 qq-maid-bot）直接使用 | 🤖 内容更新时 |
 
 注意：
 - 为提升 LaTeX 兼容性，PDF 导出会移除 Markdown 删除线（`~~text~~`）标记并将 admonition 标题图标替换为纯文字。

--- a/tools/export_knowledge.py
+++ b/tools/export_knowledge.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+知识库干净版导出工具
+
+将 docs/entries/*.md 转换为适合 qq-maid-bot KNOWLEDGE_DIR 的干净 Markdown：
+  - 保留 Frontmatter 和正文知识
+  - 删除导航章节（相关条目、参见、参考资料等）
+  - 清理 MkDocs admonition 语法，保留有效正文
+  - Markdown 链接转纯文字
+  - 删除图片和脚注
+  - 删除模板化站点免责声明
+
+用法：
+    uv run python3 tools/export_knowledge.py \\
+        --input docs/entries \\
+        --output dist/knowledge/entries
+
+    make knowledge
+
+多次执行结果稳定，不修改源文件。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Set, Tuple
+
+
+# ── 集中维护的模板文本列表 ──────────────────────────────────
+# 这些是站点模板重复套话，在导出时删除。
+
+TEMPLATE_TEXTS: List[str] = [
+    # 标准免责声明 variants
+    "本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员。",
+    "本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员",
+    "本站资料仅供参考,不构成医疗建议。若需诊断或治疗,请联系持证专业人员。",
+    "如果您有紧急情况或需要专业帮助，请立即联系当地紧急服务或心理健康专业人员。",
+    # 触发警告
+    "内容涉及创伤、精神健康、自我认同等敏感议题，阅读时请留意自身状态。",
+    "内容涉及创伤、精神健康、自我认同等敏感议题,阅读时请留意自身状态。",
+]
+
+TEMPLATE_TEXT_PATTERNS: List[re.Pattern] = [
+    # 可配置的正则模式，用于匹配有细微变化的模板文本
+    re.compile(
+        r"本站资料仅供参考[，,]\s*不构成医疗建议[。.]\s*"
+        r"若需诊断或治疗[，,]\s*请联系持证专业人员[。.]?"
+    ),
+    re.compile(
+        r"如果您有紧急情况或需要专业帮助[，,]\s*"
+        r"请立即联系当地紧急服务或心理健康专业人员[。.]?"
+    ),
+    re.compile(
+        r"内容涉及创伤[、,]\s*精神健康[、,]\s*自我认同等敏感议题[，,]\s*"
+        r"阅读时请留意自身状态[。.]?"
+    ),
+]
+
+
+# ── 导航章节标题（删除该标题及其以下全部内容直到下一个同级/更高级标题） ──
+
+NAV_SECTION_HEADINGS: List[re.Pattern] = [
+    re.compile(r"^#{2,6}\s*相关条目\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*关联条目\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*参见\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*另见\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*See also\s*[#:：]*$", re.IGNORECASE),
+]
+
+REF_SECTION_HEADINGS: List[re.Pattern] = [
+    re.compile(r"^#{2,6}\s*延伸阅读\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*参考与延伸阅读\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*参考文献\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*参考资料\s*[#:：\s]*$"),
+    re.compile(r"^#{2,6}\s*外部链接\s*[#:：\s]*$"),
+]
+
+ALL_SECTION_HEADINGS: List[re.Pattern] = NAV_SECTION_HEADINGS + REF_SECTION_HEADINGS
+
+
+# ── 统计报告 ──
+
+@dataclass
+class ExportStats:
+    """单文件导出统计。"""
+    nav_sections_removed: int = 0
+    ref_sections_removed: int = 0
+    links_converted: int = 0
+    admonitions_cleaned: int = 0
+    images_removed: int = 0
+    footnotes_removed: int = 0
+    template_texts_removed: int = 0
+    error: Optional[str] = None
+
+    def merge(self, other: ExportStats) -> None:
+        self.nav_sections_removed += other.nav_sections_removed
+        self.ref_sections_removed += other.ref_sections_removed
+        self.links_converted += other.links_converted
+        self.admonitions_cleaned += other.admonitions_cleaned
+        self.images_removed += other.images_removed
+        self.footnotes_removed += other.footnotes_removed
+        self.template_texts_removed += other.template_texts_removed
+
+
+# ── 核心处理 ──
+
+def _is_heading(line: str) -> bool:
+    """判断一行是否为 Markdown 标题。"""
+    stripped = line.strip()
+    return stripped.startswith("#") and stripped[0] == "#"
+
+
+def _heading_level(line: str) -> int:
+    """返回标题层级（1-6），不是标题返回 0。"""
+    stripped = line.strip()
+    if not (stripped.startswith("#") and stripped[0] == "#"):
+        return 0
+    level = 0
+    for ch in stripped:
+        if ch == "#":
+            level += 1
+        else:
+            break
+    return level
+
+
+def _is_nav_heading(line: str) -> bool:
+    """检查一行是否为需要删除的导航章节标题。"""
+    for pattern in ALL_SECTION_HEADINGS:
+        if pattern.match(line):
+            return True
+    return False
+
+
+def _is_ref_heading(line: str) -> bool:
+    """检查一行是否为参考/文献章节标题。"""
+    for pattern in REF_SECTION_HEADINGS:
+        if pattern.match(line):
+            return True
+    return False
+
+
+def _clean_admonition_block(
+    lines: List[str], start_idx: int, stats: ExportStats
+) -> Tuple[List[str], int]:
+    """
+    处理 admonition 块（以 `!!!` 或 `???` 开头）。
+    
+    返回 (处理后行列表, 下一个要处理的行索引)。
+    处理后行列表可能为空（空admonition）或包含去除缩进的正文。
+    """
+    line = lines[start_idx]
+    stripped = line.rstrip()
+    
+    # 匹配 !!! type "title" 或 ??? type "title"
+    m = re.match(r'^[!?]{3}\s+(\w+)(?:\s+"([^"]*)")?\s*$', stripped)
+    if not m:
+        # 可能是 !!! type 无标题
+        m = re.match(r'^[!?]{3}\s+(\w+)\s*$', stripped)
+    if not m:
+        return [line], start_idx + 1  # fallback: 保持原样
+    
+    admon_type = m.group(1)
+    _admon_title = m.group(2) if m.lastindex and m.lastindex >= 2 else ""
+    
+    # 收集正文行（缩进的内容）
+    body_lines: List[str] = []
+    idx = start_idx + 1
+    indent: Optional[str] = None
+    
+    while idx < len(lines):
+        l = lines[idx]
+        if l.strip() == "":
+            body_lines.append(l)
+            idx += 1
+            continue
+        # 检测缩进
+        leading_space = len(l) - len(l.lstrip())
+        if leading_space < 4 and l.strip():
+            # 缩进不足，说明 admonition 结束
+            break
+        if indent is None:
+            indent = " " * leading_space
+        # 去除共同缩进
+        if indent and l.startswith(indent):
+            body_lines.append(l[len(indent):])
+        else:
+            body_lines.append(l)
+        idx += 1
+    
+    # 去除首尾空行
+    while body_lines and body_lines[0].strip() == "":
+        body_lines.pop(0)
+    while body_lines and body_lines[-1].strip() == "":
+        body_lines.pop()
+    
+    # 检查是否为纯模板文本
+    body_text = " ".join(l.strip() for l in body_lines if l.strip())
+    is_template = any(
+        tmpl in body_text for tmpl in TEMPLATE_TEXTS
+    ) or any(p.search(body_text) for p in TEMPLATE_TEXT_PATTERNS)
+    
+    if is_template:
+        stats.template_texts_removed += 1
+        stats.admonitions_cleaned += 1
+        return [], idx
+    
+    if not body_lines:
+        # 空 admonition
+        stats.admonitions_cleaned += 1
+        return [], idx
+    
+    stats.admonitions_cleaned += 1
+    
+    # 对 ??? 可折叠块（FAQ 问题），保留标题文字
+    if stripped.startswith("???"):
+        title = (_admon_title or "").strip()
+        if title:
+            body_lines.insert(0, f"**{title}**\n")
+    
+    return body_lines, idx
+
+
+def _is_footnote_def(line: str) -> bool:
+    """检查是否为脚注定义行如 [^ref]: ..."""
+    return bool(re.match(r'^\[\^[^\]]+\]:\s*', line.strip()))
+
+
+def _remove_images_from_line(line: str, stats: ExportStats) -> str:
+    """
+    从行中删除所有 Markdown 图片语法 ![...](...)，包括 SVG/PNG/JPG 等。
+    返回处理后行内容（保留原始缩进）。
+    """
+    img_pattern = re.compile(r'!\[[^\]]*\]\([^)]+\)')
+    new_line, count = img_pattern.subn("", line)
+    stats.images_removed += count
+    if count > 0:
+        # 删除图片后清理多余空格，但保留缩进
+        indent = line[:len(line) - len(line.lstrip())]
+        rest = new_line.strip()
+        return indent + rest if rest else ""
+    return line
+
+
+def _convert_links_in_line(line: str) -> Tuple[str, int]:
+    """
+    将行内 Markdown 链接 [text](url) / [text](url "title") 替换为纯文字。
+    返回 (新行, 转换次数)。
+    
+    注意：图片语法 ![...](...) 不在此处理（另有专门删除步骤）。
+    """
+    count = 0
+    new_line = line
+    
+    # 匹配非图片的 Markdown 链接
+    # 规则：排除 ! 开头的，匹配 [text](url) 和 [text](url "title") 以及 [text](<url>)
+    link_pattern = re.compile(
+        r'(?<!!)\[(?P<text>[^\]]+)\]\('
+        r'(?:<(?P<bracket_url>[^>]+)>|(?P<url>[^)\s]+(?:\([^)]*\))?[^)\s]*))'
+        r'(?:\s+"[^"]*")?\s*\)'
+    )
+    
+    def _replacer(m: re.Match) -> str:
+        nonlocal count
+        text = m.group("text")
+        if text:
+            count += 1
+            return text
+        return m.group(0)
+    
+    new_line = link_pattern.sub(_replacer, new_line)
+    return new_line, count
+
+
+def _count_heading_in_text(text: str) -> int:
+    """统计文本中包含的导航章节数量（用于粗略统计）。"""
+    count = 0
+    for line in text.split("\n"):
+        if _is_nav_heading(line):
+            count += 1
+    return count
+
+
+def _remove_footnote_defs(text: str, stats: ExportStats) -> str:
+    """
+    删除脚注定义 [^ref]: ... 及其缩进后续行。
+    """
+    lines = text.split("\n")
+    result: List[str] = []
+    skip_until = -1
+    
+    for i, line in enumerate(lines):
+        if i < skip_until:
+            continue
+        if _is_footnote_def(line):
+            stats.footnotes_removed += 1
+            # 跳过后续缩进行
+            j = i + 1
+            while j < len(lines):
+                l = lines[j]
+                if l.strip() == "" or l.startswith(" ") or l.startswith("\t"):
+                    j += 1
+                else:
+                    break
+            skip_until = j
+            continue
+        result.append(line)
+    
+    return "\n".join(result)
+
+
+def _remove_inline_footnotes_global(text: str) -> Tuple[str, int]:
+    """删除正文中所有行内脚注引用 [^ref]。"""
+    fn_pattern = re.compile(r'\[\^[^\]]+\]')
+    new_text, count = fn_pattern.subn("", text)
+    return new_text, count
+
+
+def process_entry(content: str, stats: ExportStats) -> str:
+    """
+    对单个词条内容执行全部清洗，返回清洗后的 Markdown。
+    """
+    # ── 分离 Frontmatter ──
+    lines = content.split("\n")
+    frontmatter_lines: List[str] = []
+    body_start = 0
+    
+    if lines and lines[0].strip() == "---":
+        # 查找结束 ---
+        i = 1
+        while i < len(lines):
+            if lines[i].strip() == "---":
+                frontmatter_lines = lines[:i+1]
+                body_start = i + 1
+                break
+            i += 1
+    
+    body_lines = lines[body_start:] if body_start > 0 else lines
+    
+    # ── 处理正文 ──
+    cleaned_lines: List[str] = []
+    skip_until = -1
+    
+    i = 0
+    while i < len(body_lines):
+        if i < skip_until:
+            i += 1
+            continue
+        
+        line = body_lines[i]
+        
+        # 1) 检测导航/参考章节标题 → 删除该章节
+        if _is_nav_heading(line):
+            heading_level = _heading_level(line)
+            if _is_ref_heading(line):
+                stats.ref_sections_removed += 1
+            else:
+                stats.nav_sections_removed += 1
+            # 删除后面的内容直到下一个同级或更高级标题
+            j = i + 1
+            while j < len(body_lines):
+                next_line = body_lines[j]
+                if _is_heading(next_line) and _heading_level(next_line) <= heading_level:
+                    break
+                j += 1
+            i = j
+            continue
+        
+        # 2) 检测 admonition
+        stripped_line = line.lstrip()
+        if stripped_line.startswith("!!!") or stripped_line.startswith("???"):
+            processed, next_idx = _clean_admonition_block(body_lines, i, stats)
+            if processed:
+                # 对 admonition 正文也执行链接转换（脚注留到全局阶段）
+                for pl in processed:
+                    pl_clean, lc = _convert_links_in_line(pl)
+                    stats.links_converted += lc
+                    cleaned_lines.append(pl_clean)
+            i = next_idx
+            continue
+        
+        # 3) 删除行内图片（包括 SVG/PNG/JPG 等）
+        line_no_img = _remove_images_from_line(line, stats)
+        
+        # 4) 转换链接（非图片）
+        new_line, link_count = _convert_links_in_line(line_no_img)
+        stats.links_converted += link_count
+        
+        cleaned_lines.append(new_line)
+        i += 1
+    
+    # ── 重建正文 ──
+    body_text = "\n".join(cleaned_lines)
+    
+    # ── 删除脚注定义（必须在删除行内脚注引用之前） ──
+    body_text = _remove_footnote_defs(body_text, stats)
+    
+    # ── 删除行内脚注引用 ──
+    body_text, fn_count = _remove_inline_footnotes_global(body_text)
+    stats.footnotes_removed += fn_count
+    
+    # ── 删除模板文本（admonition 外的自由文本） ──
+    for tmpl in TEMPLATE_TEXTS:
+        while tmpl in body_text:
+            stats.template_texts_removed += 1
+            body_text = body_text.replace(tmpl, "")
+    for pattern in TEMPLATE_TEXT_PATTERNS:
+        body_text, count = pattern.subn("", body_text)
+        stats.template_texts_removed += count
+    
+    # ── 清理空行和孤立分隔线 ──
+    body_text = _cleanup_whitespace(body_text)
+    
+    # ── 合并 Frontmatter 和清洗后的正文 ──
+    if frontmatter_lines:
+        result = "\n".join(frontmatter_lines) + "\n" + body_text
+    else:
+        result = body_text
+    
+    return result
+
+
+def _remove_inline_footnotes_in_line(line: str) -> Tuple[str, int]:
+    """删除行内脚注引用，返回 (新行, 删除数量)。"""
+    fn_pattern = re.compile(r'\[\^[^\]]+\]')
+    new_line, count = fn_pattern.subn("", line)
+    # 行中可能有多处脚注引用，subn 已经处理了全部
+    return new_line, count
+
+
+def _cleanup_whitespace(text: str) -> str:
+    """
+    清理：
+      - 删除章节后产生的孤立水平分隔线（连续3+ - 或 *）
+      - 空标题（## 后面只有空白）
+      - 空列表项（- 或 * 后面只有空白）
+      - 连续超过两个空行 → 保留两个
+      - 文件开头或结尾多余空行
+    """
+    lines = text.split("\n")
+    result: List[str] = []
+    
+    for line in lines:
+        stripped = line.strip()
+        
+        # 空标题
+        if re.match(r'^#{1,6}\s*$', line):
+            continue
+        
+        # 孤立分隔线（前面是空行或文件开头，后面也是空行或文件结尾）
+        # 简单地过滤掉分隔线行
+        if re.match(r'^[-*_]{3,}\s*$', stripped) and not stripped.startswith("---"):
+            # 跳过可能的分隔线（--- 是 Frontmatter 分隔符，不删）
+            continue
+        
+        # 空列表项
+        if re.match(r'^[\s]*[-*+]\s*$', line):
+            continue
+        if re.match(r'^[\s]*\d+\.\s*$', line):
+            continue
+        
+        result.append(line)
+    
+    text = "\n".join(result)
+    
+    # 连续超过两个空行 → 保留两个
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    
+    # 文件开头和结尾空行
+    text = text.strip()
+    
+    return text
+
+
+# ── 安全检查 ──
+
+# 禁止的输出目录列表（相对路径会自动解析为绝对路径比较）
+FORBIDDEN_OUTPUT_DIRS: Set[str] = {
+    "/",
+}
+
+
+def check_output_safety(input_dir: Path, output_dir: Path) -> None:
+    """
+    检查输出目录安全性。
+    
+    Raises:
+        ValueError: 如果输出目录不安全。
+    """
+    input_resolved = input_dir.resolve()
+    output_resolved = output_dir.resolve()
+    
+    # 输入输出不能相同
+    if input_resolved == output_resolved:
+        raise ValueError(
+            f"输入目录和输出目录不能相同: {input_resolved}"
+        )
+    
+    repo_root = Path(__file__).resolve().parent.parent
+    
+    # 输出目录不能是仓库根目录或 docs/entries/
+    forbidden = [
+        repo_root,
+        repo_root / "docs" / "entries",
+        input_resolved,
+    ]
+    for forbidden_path in forbidden:
+        if output_resolved == forbidden_path:
+            raise ValueError(
+                f"输出目录不得为禁止目录: {output_resolved}"
+            )
+    
+    # 输出目录不能位于 docs/ 下（包括 docs/ 本身）
+    if str(output_resolved).startswith(str(repo_root / "docs")):
+        raise ValueError(
+            f"输出目录不得位于 docs/ 下: {output_resolved}"
+        )
+
+
+# ── 主入口 ──
+
+@dataclass
+class ExportResult:
+    """导出结果。"""
+    scanned: int = 0
+    exported: int = 0
+    failed: int = 0
+    errors: List[Tuple[str, str]] = field(default_factory=list)  # (filename, error)
+    total_stats: ExportStats = field(default_factory=ExportStats)
+
+
+def export_knowledge(input_dir: Path, output_dir: Path) -> ExportResult:
+    """
+    执行知识导出。
+    
+    Args:
+        input_dir: 源词条目录（如 docs/entries/）
+        output_dir: 输出目录（如 dist/knowledge/entries/）
+    
+    Returns:
+        导出结果对象。
+    """
+    result = ExportResult()
+    
+    # 安全检查
+    check_output_safety(input_dir, output_dir)
+    
+    # 确保输出目录存在
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # 清理旧生成文件，但只限 .md 文件以避免误删
+    if output_dir.exists():
+        for old_file in output_dir.glob("*.md"):
+            old_file.unlink()
+    
+    # 扫描输入文件
+    md_files = sorted(input_dir.glob("*.md"))
+    result.scanned = len(md_files)
+    
+    for md_file in md_files:
+        try:
+            content = md_file.read_text(encoding="utf-8")
+            stats = ExportStats()
+            cleaned = process_entry(content, stats)
+            
+            # 写入输出
+            output_path = output_dir / md_file.name
+            output_path.write_text(cleaned + "\n", encoding="utf-8")
+            
+            result.exported += 1
+            if stats.error:
+                result.failed += 1
+                result.errors.append((md_file.name, stats.error))
+            result.total_stats.merge(stats)
+        except Exception as e:
+            result.failed += 1
+            result.errors.append((md_file.name, str(e)))
+    
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="知识库干净版导出工具 - 将 wiki 词条导出为适合全文检索的干净 Markdown",
+    )
+    parser.add_argument(
+        "--input", "-i",
+        default="docs/entries",
+        help="源词条目录（默认: docs/entries）",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default="dist/knowledge/entries",
+        help="输出目录（默认: dist/knowledge/entries）",
+    )
+    args = parser.parse_args()
+    
+    input_dir = Path(args.input)
+    output_dir = Path(args.output)
+    
+    if not input_dir.is_dir():
+        print(f"错误: 输入目录不存在: {input_dir}", file=sys.stderr)
+        sys.exit(1)
+    
+    try:
+        result = export_knowledge(input_dir, output_dir)
+    except ValueError as e:
+        print(f"安全错误: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    # 输出统计报告
+    stats = result.total_stats
+    print(f"\n{'='*50}")
+    print(f"  知识库导出完成")
+    print(f"{'='*50}")
+    print(f"  扫描文件数:        {result.scanned}")
+    print(f"  成功导出文件数:    {result.exported}")
+    print(f"  失败/跳过文件数:   {result.failed}")
+    print(f"  ─────────────────────────────")
+    print(f"  删除导航章节数:    {stats.nav_sections_removed}")
+    print(f"  删除参考章节数:    {stats.ref_sections_removed}")
+    print(f"  转换链接数:        {stats.links_converted}")
+    print(f"  清理 admonition 数: {stats.admonitions_cleaned}")
+    print(f"  删除图片数:        {stats.images_removed}")
+    print(f"  删除脚注数:        {stats.footnotes_removed}")
+    print(f"  删除模板文本数:    {stats.template_texts_removed}")
+    print(f"  输出目录:          {output_dir.resolve()}")
+    print(f"{'='*50}\n")
+    
+    if result.errors:
+        print("失败文件详情:")
+        for fname, err in result.errors:
+            print(f"  ❌ {fname}: {err}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_export_knowledge.py
+++ b/tools/test_export_knowledge.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+测试 export_knowledge.py 的清洗规则。
+
+运行:
+    uv run python3 -m pytest tools/test_export_knowledge.py -v
+
+或直接:
+    uv run python3 tools/test_export_knowledge.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+# 确保可以从 tools/ 目录导入
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from export_knowledge import (
+    ExportStats,
+    check_output_safety,
+    process_entry,
+    export_knowledge,
+)
+
+
+# ── 测试数据 ──
+
+SAMPLE_WITH_FRONTMATTER = """---
+title: 测试词条（Test Entry）
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 测试词条（Test Entry）
+
+## 概述
+
+这是一个测试词条，用于验证导出工具。
+
+### 子标题
+
+正文内容包含 **粗体** 和 *斜体*。
+
+## 相关条目
+
+- [DID](DID.md)
+- [OSDD](OSDD.md)
+
+## 参考与延伸阅读
+
+1. 参考书 A
+2. 参考书 B
+"""
+
+SAMPLE_WITH_LINKS = """---
+title: 链接测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 链接测试
+
+这是一个[普通链接](DID.md)。
+
+这是一个带标题的[链接](DID.md "标题文字")。
+
+这是一个[括号链接](<DID.md>)。
+
+这是一个[外部链接](https://example.com)。
+
+正文包含 DID 与 OSDD 的概念比较。
+"""
+
+SAMPLE_WITH_IMAGES = """---
+title: 图片测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 图片测试
+
+文字内容。
+
+![测试图片](../assets/images/test.png)
+
+![SVG图片](../assets/figures/diagram.svg)
+
+文字再接续。
+"""
+
+SAMPLE_WITH_ADMONITIONS = """---
+title: Admonition 测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# Admonition 测试
+
+!!! warning "触发警告"
+    内容涉及敏感议题。
+
+!!! info "免责声明"
+    本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员。
+
+!!! tip "有用的提示"
+    这是一个有用的提示正文。
+
+## 正文标题
+
+正文内容。
+
+??? question "这是一个问题？"
+    这是问题的回答。
+
+!!! note "无内容的"
+"""
+
+SAMPLE_WITH_FOOTNOTES = """---
+title: 脚注测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 脚注测试
+
+正文包含脚注引用[^fn1]。
+
+更多内容[^fn2]。
+
+## 正文标题
+
+正文继续。
+
+[^fn1]: 第一个脚注定义。
+[^fn2]: 第二个脚注定义，
+    带缩进的多行内容。
+"""
+
+SAMPLE_WITH_TABLES = """---
+title: 表格测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 表格测试
+
+| 列1 | 列2 |
+|-----|-----|
+| 数据1 | 数据2 |
+| 数据3 | 数据4 |
+
+正文内容。
+"""
+
+SAMPLE_WITH_CODE = """---
+title: 代码测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 代码测试
+
+正文。
+
+```python
+def hello():
+    print("world")
+```
+
+行内 `代码` 应该保留。
+"""
+
+SAMPLE_NAV_IN_BODY = """---
+title: 正文中关键词测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 正文中关键词测试
+
+在诊断过程中，相关条目需要仔细检查。
+
+参见相关文献资料时，注意区分。
+
+该参考资料来源于临床研究。
+"""
+
+SAMPLE_NAV_MULTI_LEVEL = """---
+title: 多级导航测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 多级导航测试
+
+## 诊断要点
+
+### ICD-11 条目
+
+内容。
+
+## 相关条目
+
+### 子分类一
+
+- [DID](DID.md)
+
+### 子分类二
+
+- [OSDD](OSDD.md)
+
+## 治疗
+
+治疗内容。
+"""
+
+SAMPLE_TEMPLATE_TEXT = """---
+title: 模板文本测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 模板文本测试
+
+正文内容。
+
+本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员。
+
+更多正文。
+"""
+
+SAMPLE_WHITESPACE = """---
+title: 空白清理测试
+tags:
+  - dx:测试
+topic: 理论与分类
+updated: 2026-01-01
+---
+
+# 空白清理测试
+
+正文。
+
+
+---
+
+更多正文。
+
+---
+"""
+
+SAMPLE_FRONTMATTER_PRESERVATION = """---
+title: Frontmatter 测试
+tags:
+  - dx:测试
+  - theory:理论
+topic: 理论与分类
+search:
+  boost: 1.5
+description: 一个测试词条
+synonyms:
+  - 测试
+  - test
+updated: 2026-06-01
+---
+
+# Frontmatter 测试
+
+正文。
+"""
+
+
+# ── 辅助函数 ──
+
+def _run(content: str) -> str:
+    """对内容运行完整清洗，返回结果。"""
+    stats = ExportStats()
+    return process_entry(content, stats)
+
+
+def test_frontmatter_preserved():
+    """Frontmatter 原样保留。"""
+    result = _run(SAMPLE_WITH_FRONTMATTER)
+    assert "title: 测试词条（Test Entry）" in result
+    assert "tags:" in result
+    assert "dx:测试" in result
+    assert "topic: 理论与分类" in result
+    assert "updated: 2026-01-01" in result
+    assert result.startswith("---")
+
+
+def test_nav_section_removed():
+    """相关条目 章节被删除。"""
+    result = _run(SAMPLE_WITH_FRONTMATTER)
+    assert "## 相关条目" not in result
+    assert "[DID](DID.md)" not in result
+    assert "## 参考与延伸阅读" not in result
+
+
+def test_nav_stops_at_next_same_level():
+    """导航章节删除到下一个同级标题时停止。"""
+    result = _run(SAMPLE_NAV_MULTI_LEVEL)
+    assert "## 相关条目" not in result
+    assert "### 子分类一" not in result
+    assert "### 子分类二" not in result
+    assert "[DID](DID.md)" not in result or "DID" not in result.replace("---", "")
+    # 下一个同级标题 "## 治疗" 应该保留
+    assert "## 治疗" in result
+    assert "治疗内容" in result
+
+
+def test_nav_keyword_not_removed_in_body():
+    """普通正文中的“相关条目”文字不被误删。"""
+    result = _run(SAMPLE_NAV_IN_BODY)
+    assert "相关条目" in result  # 正文中出现的不能被误删
+    assert "参见" in result
+    assert "参考资料" in result
+    assert "诊断" in result
+
+
+def test_links_converted_to_text():
+    """Markdown 链接转纯文字。"""
+    result = _run(SAMPLE_WITH_LINKS)
+    assert "普通链接" in result
+    assert "[普通链接](DID.md)" not in result
+    assert "带标题的链接" in result
+    assert "标题文字" not in result  # URL title 应该被删除
+    assert "外部链接" in result
+    assert "https://" not in result or "https" not in ''.join(result.split())
+
+
+def test_images_removed():
+    """图片被删除。"""
+    result = _run(SAMPLE_WITH_IMAGES)
+    assert "![测试图片](../assets/images/test.png)" not in result
+    assert "![SVG图片](../assets/figures/diagram.svg)" not in result
+    assert "文字内容" in result
+    assert "文字再接续" in result
+
+
+def test_admonition_marker_removed():
+    """admonition 标记和标题被删除。"""
+    result = _run(SAMPLE_WITH_ADMONITIONS)
+    assert "!!!" not in result
+    # 触发警告被删除（模板文本）
+    assert "触发警告" not in result
+    # 免责声明被删除
+    assert "本站资料仅供参考，不构成医疗建议" not in result
+    # tip 的标题 "有用的提示" 在正文 "这是一个有用的提示正文" 中作为子串存在，
+    # 但 admonition 语法标记已被删除，且标题未作为独立标题输出
+    assert "!!! tip" not in result
+    assert "这是一个有用的提示正文" in result
+
+
+def test_admonition_body_indentation_removed():
+    """admonition 正文去缩进并保留。"""
+    result = _run(SAMPLE_WITH_ADMONITIONS)
+    assert "这是一个有用的提示正文" in result
+    # 确认没有多余的缩进
+    for line in result.split("\n"):
+        if "这是一个有用的提示正文" in line:
+            assert not line.startswith("    "), f"缩进未清除: {line!r}"
+
+
+def test_question_admonition_title_preserved():
+    """??? question 的标题（问题）被保留。"""
+    result = _run(SAMPLE_WITH_ADMONITIONS)
+    assert "这是一个问题？" in result
+    assert "这是问题的回答" in result
+
+
+def test_footnote_definitions_removed():
+    """单行脚注定义被删除。"""
+    result = _run(SAMPLE_WITH_FOOTNOTES)
+    assert "[^fn1]:" not in result
+    assert "第一个脚注定义" not in result  # 定义内容也被删除
+    # 但正文内容保留
+    assert "正文包含脚注引用" in result
+
+
+def test_footnote_multi_line_removed():
+    """多行脚注定义被删除。"""
+    result = _run(SAMPLE_WITH_FOOTNOTES)
+    assert "[^fn2]:" not in result
+    assert "带缩进的多行内容" not in result  # 多行定义内容也被删除
+
+
+def test_inline_footnotes_removed():
+    """行内脚注引用被删除。"""
+    result = _run(SAMPLE_WITH_FOOTNOTES)
+    assert "[^fn1]" not in result
+    assert "正文包含脚注引用" in result
+    assert "更多内容" in result
+
+
+def test_tables_preserved():
+    """表格保留。"""
+    result = _run(SAMPLE_WITH_TABLES)
+    assert "| 列1 | 列2 |" in result
+    assert "| 数据1 | 数据2 |" in result
+
+
+def test_code_blocks_preserved():
+    """代码块保留。"""
+    result = _run(SAMPLE_WITH_CODE)
+    assert "```python" in result
+    assert 'def hello():' in result
+    assert '`代码`' in result or "`代码`" in result
+
+
+def test_bold_italic_preserved():
+    """粗体和斜体保留。"""
+    result = _run(SAMPLE_WITH_FRONTMATTER)
+    assert "**粗体**" in result
+    assert "*斜体*" in result
+
+
+def test_template_text_removed():
+    """模板化免责声明被删除。"""
+    result = _run(SAMPLE_TEMPLATE_TEXT)
+    assert "本站资料仅供参考，不构成医疗建议" not in result
+    assert "正文内容" in result
+    assert "更多正文" in result
+
+
+def test_excessive_blank_lines_removed():
+    """连续超过两个空行被清理。"""
+    result = _run(SAMPLE_WHITESPACE)
+    # 不应该有连续 3+ 空行
+    assert "正文\n\n\n" not in result
+
+
+def test_output_safety():
+    """输出目录安全检查。"""
+    import pytest
+    from pathlib import Path
+    
+    repo_root = Path(__file__).resolve().parent.parent
+    
+    # 不能与输入目录相同
+    with pytest.raises(ValueError, match="输入目录和输出目录不能相同"):
+        check_output_safety(repo_root / "docs/entries", repo_root / "docs/entries")
+    
+    # 不能是仓库根目录
+    with pytest.raises(ValueError, match="输出目录不得为禁止目录"):
+        check_output_safety(repo_root / "docs/entries", repo_root)
+    
+    # 不能是 docs/
+    with pytest.raises(ValueError, match="输出目录不得位于 docs/ 下"):
+        check_output_safety(repo_root / "docs/entries", repo_root / "docs")
+    
+    # 不能是 docs/entries/
+    with pytest.raises(ValueError, match="输出目录不得为禁止目录"):
+        check_output_safety(repo_root / "tools", repo_root / "docs/entries")
+    
+    # 合法路径
+    check_output_safety(repo_root / "docs/entries", repo_root / "dist" / "knowledge" / "entries")
+
+
+def test_repeatable_output():
+    """重复执行结果一致。"""
+    content = SAMPLE_WITH_FRONTMATTER
+    result1 = _run(content)
+    result2 = _run(content)
+    assert result1 == result2
+
+
+def test_idempotent():
+    """对已清洗内容再次清洗仍保持一致。"""
+    content = SAMPLE_WITH_LINKS
+    result1 = _run(content)
+    result2 = _run(result1)  # 对结果再跑一次
+    assert result1 == result2
+
+
+def test_export_integration():
+    """集成测试：导出、删除源文件后旧输出不残留。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        input_dir = tmp / "input"
+        output_dir = tmp / "output"
+        input_dir.mkdir()
+        
+        # 创建两个源文件
+        (input_dir / "test-a.md").write_text(SAMPLE_WITH_FRONTMATTER, encoding="utf-8")
+        (input_dir / "test-b.md").write_text(SAMPLE_WITH_LINKS, encoding="utf-8")
+        
+        result = export_knowledge(input_dir, output_dir)
+        assert result.exported == 2
+        assert (output_dir / "test-a.md").exists()
+        assert (output_dir / "test-b.md").exists()
+        
+        # 删除一个源文件后重新导出
+        (input_dir / "test-a.md").unlink()
+        result2 = export_knowledge(input_dir, output_dir)
+        assert result2.exported == 1
+        # 旧输出文件不应残留
+        assert not (output_dir / "test-a.md").exists()
+        assert (output_dir / "test-b.md").exists()
+
+
+def test_file_no_frontmatter():
+    """没有 Frontmatter 的文件也能正确处理。"""
+    content = "# 无 Frontmatter 的文件\n\n正文内容。\n\n## 相关条目\n\n- [DID](DID.md)"
+    result = _run(content)
+    assert "# 无 Frontmatter 的文件" in result
+    assert "## 相关条目" not in result
+    assert "正文内容" in result
+
+
+def test_all_nav_headings_removed():
+    """所有导航标题变体都被删除。"""
+    variants = [
+        "## 相关条目",
+        "### 关联条目",
+        "## 参见",
+        "### 另见",
+        "## See also",
+        "## See Also",
+        "## 延伸阅读",
+        "## 参考与延伸阅读",
+        "## 参考文献",
+        "## 参考资料",
+        "## 外部链接",
+    ]
+    for heading in variants:
+        content = f"---\ntitle: Test\ntags:\n  - dx:test\ntopic: 理论与分类\nupdated: 2026-01-01\n---\n\n# Test\n\n{heading}\n\n内容。"
+        result = _run(content)
+        assert heading.strip() not in result, f"标题未被删除: {heading}"
+
+
+def test_nav_heading_trailing_punctuation():
+    """导航标题带标点也能匹配。"""
+    content = f"---\ntitle: Test\ntags:\n  - dx:test\ntopic: 理论与分类\nupdated: 2026-01-01\n---\n\n# Test\n\n## 相关条目：\n\n- [DID](DID.md)\n\n## 正文\n\n内容。"
+    result = _run(content)
+    assert "## 相关条目：" not in result
+    assert "## 正文" in result
+    assert "内容。" in result
+
+
+def test_statistics_reporting():
+    """统计报告正确反映操作次数。"""
+    stats = ExportStats()
+    _ = process_entry(SAMPLE_WITH_ADMONITIONS, stats)
+    assert stats.admonitions_cleaned >= 3  # warning, info, tip, note → 至少3个非空
+    assert stats.template_texts_removed >= 1  # 免责声明
+    assert stats.nav_sections_removed >= 0  # 没有导航章节
+
+
+# ── 主入口（直接运行时用 pytest） ──
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## 变更内容

新增 **export_knowledge.py** 工具，将 `docs/entries/*.md` 导出为适合 qq-maid-bot 等全文检索引擎的干净 Markdown。

### 导出规则

| 规则 | 处理方式 |
|------|---------|
| Frontmatter | 完整保留 |
| 导航章节（相关条目、参见、另见等） | 删除整章 |
| 参考章节（参考文献、延伸阅读、外部链接等） | 删除整章 |
| MkDocs admonition | 去除语法标记和标题，保留有效正文 |
| Markdown 链接 | 转纯文字（保留显示文字） |
| 图片（含 SVG） | 删除 |
| 脚注引用和定义 | 删除 |
| 模板化免责声明 | 删除 |
| 连续空行/空标题/孤立分隔线 | 清理 |

### 使用方式

```bash
make knowledge
# 或
uv run python3 tools/export_knowledge.py --input docs/entries --output dist/knowledge/entries
```

输出目录 `dist/knowledge/entries` 可直接配置为 qq-maid-bot 的 `KNOWLEDGE_DIR`。

### 测试

25 项自动化测试覆盖全部清洗规则，包括导航章节删除边界、admonition 清理、链接转换、图片删除、脚注（含多行）删除、表格/代码块保留、输出安全检查、重复执行一致性等。

### 验证

- ✅ `make knowledge`: 343 文件全部成功导出
- ✅ `make check`: links/tags/frontmatter/build 全部通过
- ✅ `make build`: MkDocs 构建成功
- ✅ 两次执行输出一致
- ✅ 源文件未修改

### 修改文件

- `tools/export_knowledge.py` - 新增导出工具
- `tools/test_export_knowledge.py` - 新增测试
- `Makefile` - 新增 `make knowledge` 命令
- `.gitignore` - 排除 `dist/knowledge/`
- `docs/dev/Tools-Index.md` - 添加工具文档